### PR TITLE
Allow annotated field with JsonKey.unknownEnumValue to be of type List

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.4.1-dev
+## 3.4.2-dev
 
 - `JsonKey.unknownEnumValue`
   - Added support for `unknownEnumValue` on `List` of enums

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Support properties where the getter is defined in a class with a corresponding
   setter in a super type.
+- `JsonKey.unknownEnumValue`
+  - Added support for `unknownEnumValue` on `List` of enums
 
 ## 3.4.0
 

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,9 +1,12 @@
+## 3.4.1-dev
+
+- `JsonKey.unknownEnumValue`
+  - Added support for `unknownEnumValue` on `List` of enums
+
 ## 3.4.1
 
 - Support properties where the getter is defined in a class with a corresponding
   setter in a super type.
-- `JsonKey.unknownEnumValue`
-  - Added support for `unknownEnumValue` on `List` of enums
 
 ## 3.4.0
 

--- a/json_serializable/lib/src/json_key_utils.dart
+++ b/json_serializable/lib/src/json_key_utils.dart
@@ -136,7 +136,8 @@ JsonKey _from(FieldElement element, JsonSerializable classAnnotation) {
         ? null
         : iterateEnumFields(annotationValue.objectValue.type);
     if (enumFields != null) {
-      if (mustBeEnum && !(isEnum(element.type) || isList(element.type))) {
+      if (mustBeEnum &&
+          !(isEnum(element.type) || element.type.isDartCoreList)) {
         throwUnsupported(
           element,
           '`$fieldName` can only be set on fields of type enum or on lists.',

--- a/json_serializable/lib/src/json_key_utils.dart
+++ b/json_serializable/lib/src/json_key_utils.dart
@@ -127,7 +127,7 @@ JsonKey _from(FieldElement element, JsonSerializable classAnnotation) {
   /// Returns a literal object representing the value of [fieldName] in [obj].
   ///
   /// If [mustBeEnum] is `true`, throws an [InvalidGenerationSourceError] if
-  /// either the annotated field is not an `enum` or if the value in
+  /// either the annotated field is not an `enum` or `List` or if the value in
   /// [fieldName] is not an `enum` value.
   Object _annotationValue(String fieldName, {bool mustBeEnum = false}) {
     final annotationValue = obj.read(fieldName);
@@ -136,10 +136,10 @@ JsonKey _from(FieldElement element, JsonSerializable classAnnotation) {
         ? null
         : iterateEnumFields(annotationValue.objectValue.type);
     if (enumFields != null) {
-      if (mustBeEnum && !isEnum(element.type)) {
+      if (mustBeEnum && !(isEnum(element.type) || isList(element.type))) {
         throwUnsupported(
           element,
-          '`$fieldName` can only be set on fields of type enum.',
+          '`$fieldName` can only be set on fields of type enum or on lists.',
         );
       }
       final enumValueNames =

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -118,6 +118,8 @@ JsonSerializable mergeConfig(JsonSerializable config, ConstantReader reader) {
 bool isEnum(DartType targetType) =>
     targetType is InterfaceType && targetType.element.isEnum;
 
+bool isList(DartType targetType) => targetType.isDartCoreList;
+
 final _enumMapExpando = Expando<Map<FieldElement, dynamic>>();
 
 /// If [targetType] is an enum, returns a [Map] of the [FieldElement] instances

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -118,8 +118,6 @@ JsonSerializable mergeConfig(JsonSerializable config, ConstantReader reader) {
 bool isEnum(DartType targetType) =>
     targetType is InterfaceType && targetType.element.isEnum;
 
-bool isList(DartType targetType) => targetType.isDartCoreList;
-
 final _enumMapExpando = Expando<Map<FieldElement, dynamic>>();
 
 /// If [targetType] is an enum, returns a [Map] of the [FieldElement] instances

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 3.4.1
+version: 3.4.1-dev
 description: >-
   Automatically generate code for converting to and from JSON by annotating
   Dart classes.

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 3.4.1-dev
+version: 3.4.2-dev
 description: >-
   Automatically generate code for converting to and from JSON by annotating
   Dart classes.

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -95,6 +95,7 @@ const _expectedAnnotatedTests = [
   'ToJsonNullableFalseIncludeIfNullFalse',
   'TypedConvertMethods',
   'UnknownEnumValue',
+  'UnknownEnumValueList',
   'UnknownEnumValueNotEnumValue',
   'UnknownEnumValueNotEnumField',
   'UnsupportedDateTimeField',

--- a/json_serializable/test/src/unknown_enum_value_test_input.dart
+++ b/json_serializable/test/src/unknown_enum_value_test_input.dart
@@ -62,6 +62,69 @@ class UnknownEnumValue {
   UnknownEnumValueItems value;
 }
 
+@ShouldGenerate(
+r'''
+UnknownEnumValueList _$UnknownEnumValueListFromJson(Map<String, dynamic> json) {
+  return UnknownEnumValueList()
+    ..value = (json['value'] as List)
+            ?.map((e) => _$enumDecodeNullable(_$UnknownEnumValueItemsEnumMap, e,
+                unknownValue: UnknownEnumValueItems.vUnknown))
+            ?.toList() ??
+        [];
+}
+
+T _$enumDecode<T>(
+  Map<T, dynamic> enumValues,
+  dynamic source, {
+  T unknownValue,
+}) {
+  if (source == null) {
+    throw ArgumentError('A value must be provided. Supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+
+  final value = enumValues.entries
+      .singleWhere((e) => e.value == source, orElse: () => null)
+      ?.key;
+
+  if (value == null && unknownValue == null) {
+    throw ArgumentError('`$source` is not one of the supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+  return value ?? unknownValue;
+}
+
+T _$enumDecodeNullable<T>(
+  Map<T, dynamic> enumValues,
+  dynamic source, {
+  T unknownValue,
+}) {
+  if (source == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source, unknownValue: unknownValue);
+}
+
+const _$UnknownEnumValueItemsEnumMap = {
+  UnknownEnumValueItems.v0: 'v0',
+  UnknownEnumValueItems.v1: 'v1',
+  UnknownEnumValueItems.v2: 'v2',
+  UnknownEnumValueItems.vUnknown: 'vUnknown',
+  UnknownEnumValueItems.vNull: 'vNull',
+};
+''',
+)
+@JsonSerializable(
+  createToJson: false,
+)
+class UnknownEnumValueList {
+  @JsonKey(
+    defaultValue: [],
+    unknownEnumValue: UnknownEnumValueItems.vUnknown,
+  )
+  List<UnknownEnumValueItems> value;
+}
+
 enum UnknownEnumValueItems { v0, v1, v2, vUnknown, vNull }
 
 @ShouldThrow(

--- a/json_serializable/test/src/unknown_enum_value_test_input.dart
+++ b/json_serializable/test/src/unknown_enum_value_test_input.dart
@@ -63,7 +63,7 @@ class UnknownEnumValue {
 }
 
 @ShouldGenerate(
-r'''
+  r'''
 UnknownEnumValueList _$UnknownEnumValueListFromJson(Map<String, dynamic> json) {
   return UnknownEnumValueList()
     ..value = (json['value'] as List)

--- a/json_serializable/test/src/unknown_enum_value_test_input.dart
+++ b/json_serializable/test/src/unknown_enum_value_test_input.dart
@@ -76,7 +76,7 @@ class UnknownEnumValueNotEnumValue {
 
 @ShouldThrow(
   'Error with `@JsonKey` on `value`. `unknownEnumValue` can only be set on '
-  'fields of type enum.',
+  'fields of type enum or on lists.',
 )
 @JsonSerializable()
 class UnknownEnumValueNotEnumField {


### PR DESCRIPTION
This fixes https://github.com/google/json_serializable.dart/issues/585 and allows us to annotate lists with a default enum value when we encounter an unknown value.

Example:
```dart
  @JsonKey(unknownEnumValue: YourEnum.yourUnkownValue)
  final List<YourEnum> lastOrder;
```
This is currently not possible.