### PR TITLE
Add JsonSerializable.genericArgumentFactories

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,5 +16,7 @@ dev_dependencies:
   test: ^1.6.0
 
 dependency_overrides:
+  json_annotation:
+    path: ../json_annotation
   json_serializable:
     path: ../json_serializable

--- a/json_annotation/CHANGELOG.md
+++ b/json_annotation/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 3.0.2-dev
+## 3.1.0-dev
 
+- Added `JsonSerializable.genericArgumentFactories` field. 
 - Require at least Dart `2.7.0`.
 
 ## 3.0.1

--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -112,6 +112,50 @@ class JsonSerializable {
   /// fields annotated with [JsonKey].
   final FieldRename fieldRename;
 
+  /// When `true` on classes with type parameters (generic types), extra
+  /// "helper" parameters will be generated for `fromJson` and/or `toJson` to
+  /// support serializing values of those types.
+  ///
+  /// For example, the generated code for
+  ///
+  /// ```dart
+  /// @JsonSerializable(genericArgumentFactories: true)
+  /// class Response<T> {
+  ///   int status;
+  ///   T value;
+  /// }
+  /// ```
+  ///
+  /// Looks like
+  ///
+  /// ```dart
+  /// Response<T> _$ResponseFromJson<T>(
+  ///   Map<String, dynamic> json,
+  ///   T Function(Object json) helperForT,
+  /// ) {
+  ///   return Response<T>()
+  ///     ..status = json['status'] as int
+  ///     ..value = helperForT(json['value']);
+  /// }
+  ///
+  /// Map<String, dynamic> _$ResponseToJson<T>(
+  ///   Response<T> instance,
+  ///   Object Function(T value) helperForT,
+  /// ) =>
+  ///     <String, dynamic>{
+  ///       'status': instance.status,
+  ///       'value': helperForT(instance.value),
+  ///     };
+  /// ```
+  ///
+  /// Note: this option has no effect on classes class without type parameters.
+  /// A warning is printed in such cases.
+  ///
+  /// Note: if this option is set for all classes in a package via `build.yaml`
+  /// it is only applied to classes with type parameters – so no warning is
+  /// printed.
+  final bool genericArgumentFactories;
+
   /// When `true`, only fields annotated with [JsonKey] will have code
   /// generated.
   ///
@@ -151,6 +195,7 @@ class JsonSerializable {
     this.ignoreUnannotated,
     this.includeIfNull,
     this.nullable,
+    this.genericArgumentFactories,
   });
 
   factory JsonSerializable.fromJson(Map<String, dynamic> json) =>
@@ -169,6 +214,7 @@ class JsonSerializable {
     ignoreUnannotated: false,
     includeIfNull: true,
     nullable: true,
+    genericArgumentFactories: false,
   );
 
   /// Returns a new [JsonSerializable] instance with fields equal to the
@@ -188,6 +234,8 @@ class JsonSerializable {
         ignoreUnannotated: ignoreUnannotated ?? defaults.ignoreUnannotated,
         includeIfNull: includeIfNull ?? defaults.includeIfNull,
         nullable: nullable ?? defaults.nullable,
+        genericArgumentFactories:
+            genericArgumentFactories ?? defaults.genericArgumentFactories,
       );
 
   Map<String, dynamic> toJson() => _$JsonSerializableToJson(this);

--- a/json_annotation/lib/src/json_serializable.g.dart
+++ b/json_annotation/lib/src/json_serializable.g.dart
@@ -16,6 +16,7 @@ JsonSerializable _$JsonSerializableFromJson(Map<String, dynamic> json) {
       'disallow_unrecognized_keys',
       'explicit_to_json',
       'field_rename',
+      'generic_argument_factories',
       'ignore_unannotated',
       'include_if_null',
       'nullable'
@@ -35,6 +36,8 @@ JsonSerializable _$JsonSerializableFromJson(Map<String, dynamic> json) {
           $checkedConvert(json, 'ignore_unannotated', (v) => v as bool),
       includeIfNull: $checkedConvert(json, 'include_if_null', (v) => v as bool),
       nullable: $checkedConvert(json, 'nullable', (v) => v as bool),
+      genericArgumentFactories:
+          $checkedConvert(json, 'generic_argument_factories', (v) => v as bool),
     );
     return val;
   }, fieldKeyMap: const {
@@ -45,7 +48,8 @@ JsonSerializable _$JsonSerializableFromJson(Map<String, dynamic> json) {
     'explicitToJson': 'explicit_to_json',
     'fieldRename': 'field_rename',
     'ignoreUnannotated': 'ignore_unannotated',
-    'includeIfNull': 'include_if_null'
+    'includeIfNull': 'include_if_null',
+    'genericArgumentFactories': 'generic_argument_factories'
   });
 }
 
@@ -58,6 +62,7 @@ Map<String, dynamic> _$JsonSerializableToJson(JsonSerializable instance) =>
       'disallow_unrecognized_keys': instance.disallowUnrecognizedKeys,
       'explicit_to_json': instance.explicitToJson,
       'field_rename': _$FieldRenameEnumMap[instance.fieldRename],
+      'generic_argument_factories': instance.genericArgumentFactories,
       'ignore_unannotated': instance.ignoreUnannotated,
       'include_if_null': instance.includeIfNull,
       'nullable': instance.nullable,

--- a/json_annotation/pubspec.yaml
+++ b/json_annotation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_annotation
-version: 3.0.2-dev
+version: 3.1.0-dev
 description: >-
   Classes and helper functions that support JSON code generation via the
   `json_serializable` package.

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 3.4.2-dev
+## 3.5.0-dev
 
-- `JsonKey.unknownEnumValue`: Added support `Iterable`, `List`, and `Set`.
+- Added support for `JsonSerializable.genericArgumentFactories`.
+- `JsonKey.unknownEnumValue`: Added support for `Iterable`, `List`, and `Set`.
 
 ## 3.4.1
 

--- a/json_serializable/README.md
+++ b/json_serializable/README.md
@@ -81,6 +81,7 @@ is generated:
 | disallow_unrecognized_keys | [JsonSerializable.disallowUnrecognizedKeys] |                             |
 | explicit_to_json           | [JsonSerializable.explicitToJson]           |                             |
 | field_rename               | [JsonSerializable.fieldRename]              |                             |
+| generic_argument_factories | [JsonSerializable.genericArgumentFactories] |                             |
 | ignore_unannotated         | [JsonSerializable.ignoreUnannotated]        |                             |
 | include_if_null            | [JsonSerializable.includeIfNull]            | [JsonKey.includeIfNull]     |
 | nullable                   | [JsonSerializable.nullable]                 | [JsonKey.nullable]          |
@@ -93,26 +94,27 @@ is generated:
 |                            |                                             | [JsonKey.toJson]            |
 |                            |                                             | [JsonKey.unknownEnumValue]  |
 
-[JsonSerializable.anyMap]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/anyMap.html
-[JsonSerializable.checked]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/checked.html
-[JsonSerializable.createFactory]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/createFactory.html
-[JsonSerializable.createToJson]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/createToJson.html
-[JsonSerializable.disallowUnrecognizedKeys]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/disallowUnrecognizedKeys.html
-[JsonSerializable.explicitToJson]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/explicitToJson.html
-[JsonSerializable.fieldRename]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/fieldRename.html
-[JsonSerializable.ignoreUnannotated]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/ignoreUnannotated.html
-[JsonSerializable.includeIfNull]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/includeIfNull.html
-[JsonKey.includeIfNull]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/includeIfNull.html
-[JsonSerializable.nullable]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/nullable.html
-[JsonKey.nullable]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/nullable.html
-[JsonKey.defaultValue]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/defaultValue.html
-[JsonKey.disallowNullValue]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/disallowNullValue.html
-[JsonKey.fromJson]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/fromJson.html
-[JsonKey.ignore]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/ignore.html
-[JsonKey.name]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/name.html
-[JsonKey.required]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/required.html
-[JsonKey.toJson]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/toJson.html
-[JsonKey.unknownEnumValue]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/unknownEnumValue.html
+[JsonSerializable.anyMap]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/anyMap.html
+[JsonSerializable.checked]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/checked.html
+[JsonSerializable.createFactory]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/createFactory.html
+[JsonSerializable.createToJson]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/createToJson.html
+[JsonSerializable.disallowUnrecognizedKeys]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/disallowUnrecognizedKeys.html
+[JsonSerializable.explicitToJson]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/explicitToJson.html
+[JsonSerializable.fieldRename]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/fieldRename.html
+[JsonSerializable.genericArgumentFactories]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/genericArgumentFactories.html
+[JsonSerializable.ignoreUnannotated]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/ignoreUnannotated.html
+[JsonSerializable.includeIfNull]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/includeIfNull.html
+[JsonKey.includeIfNull]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/includeIfNull.html
+[JsonSerializable.nullable]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/nullable.html
+[JsonKey.nullable]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/nullable.html
+[JsonKey.defaultValue]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/defaultValue.html
+[JsonKey.disallowNullValue]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/disallowNullValue.html
+[JsonKey.fromJson]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/fromJson.html
+[JsonKey.ignore]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/ignore.html
+[JsonKey.name]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/name.html
+[JsonKey.required]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/required.html
+[JsonKey.toJson]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/toJson.html
+[JsonKey.unknownEnumValue]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/unknownEnumValue.html
 
 > Note: every `JsonSerializable` field is configurable via `build.yaml` –
   see the table for the corresponding key.
@@ -147,6 +149,7 @@ targets:
           disallow_unrecognized_keys: false
           explicit_to_json: false
           field_rename: none
+          generic_argument_factories: false
           ignore_unannotated: false
           include_if_null: true
           nullable: true

--- a/json_serializable/doc/doc.md
+++ b/json_serializable/doc/doc.md
@@ -7,6 +7,7 @@
 | disallow_unrecognized_keys | [JsonSerializable.disallowUnrecognizedKeys] |                             |
 | explicit_to_json           | [JsonSerializable.explicitToJson]           |                             |
 | field_rename               | [JsonSerializable.fieldRename]              |                             |
+| generic_argument_factories | [JsonSerializable.genericArgumentFactories] |                             |
 | ignore_unannotated         | [JsonSerializable.ignoreUnannotated]        |                             |
 | include_if_null            | [JsonSerializable.includeIfNull]            | [JsonKey.includeIfNull]     |
 | nullable                   | [JsonSerializable.nullable]                 | [JsonKey.nullable]          |
@@ -19,23 +20,24 @@
 |                            |                                             | [JsonKey.toJson]            |
 |                            |                                             | [JsonKey.unknownEnumValue]  |
 
-[JsonSerializable.anyMap]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/anyMap.html
-[JsonSerializable.checked]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/checked.html
-[JsonSerializable.createFactory]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/createFactory.html
-[JsonSerializable.createToJson]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/createToJson.html
-[JsonSerializable.disallowUnrecognizedKeys]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/disallowUnrecognizedKeys.html
-[JsonSerializable.explicitToJson]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/explicitToJson.html
-[JsonSerializable.fieldRename]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/fieldRename.html
-[JsonSerializable.ignoreUnannotated]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/ignoreUnannotated.html
-[JsonSerializable.includeIfNull]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/includeIfNull.html
-[JsonKey.includeIfNull]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/includeIfNull.html
-[JsonSerializable.nullable]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/nullable.html
-[JsonKey.nullable]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/nullable.html
-[JsonKey.defaultValue]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/defaultValue.html
-[JsonKey.disallowNullValue]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/disallowNullValue.html
-[JsonKey.fromJson]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/fromJson.html
-[JsonKey.ignore]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/ignore.html
-[JsonKey.name]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/name.html
-[JsonKey.required]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/required.html
-[JsonKey.toJson]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/toJson.html
-[JsonKey.unknownEnumValue]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/unknownEnumValue.html
+[JsonSerializable.anyMap]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/anyMap.html
+[JsonSerializable.checked]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/checked.html
+[JsonSerializable.createFactory]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/createFactory.html
+[JsonSerializable.createToJson]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/createToJson.html
+[JsonSerializable.disallowUnrecognizedKeys]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/disallowUnrecognizedKeys.html
+[JsonSerializable.explicitToJson]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/explicitToJson.html
+[JsonSerializable.fieldRename]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/fieldRename.html
+[JsonSerializable.genericArgumentFactories]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/genericArgumentFactories.html
+[JsonSerializable.ignoreUnannotated]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/ignoreUnannotated.html
+[JsonSerializable.includeIfNull]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/includeIfNull.html
+[JsonKey.includeIfNull]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/includeIfNull.html
+[JsonSerializable.nullable]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/nullable.html
+[JsonKey.nullable]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/nullable.html
+[JsonKey.defaultValue]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/defaultValue.html
+[JsonKey.disallowNullValue]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/disallowNullValue.html
+[JsonKey.fromJson]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/fromJson.html
+[JsonKey.ignore]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/ignore.html
+[JsonKey.name]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/name.html
+[JsonKey.required]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/required.html
+[JsonKey.toJson]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/toJson.html
+[JsonKey.unknownEnumValue]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/unknownEnumValue.html

--- a/json_serializable/lib/src/decode_helper.dart
+++ b/json_serializable/lib/src/decode_helper.dart
@@ -3,11 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
 
 import 'helper_core.dart';
 import 'json_literal_generator.dart';
+import 'type_helpers/generic_factory_helper.dart';
 import 'unsupported_type_error.dart';
 import 'utils.dart';
 
@@ -29,7 +31,22 @@ abstract class DecodeHelper implements HelperCore {
     final mapType = config.anyMap ? 'Map' : 'Map<String, dynamic>';
     buffer.write('$targetClassReference '
         '${prefix}FromJson${genericClassArgumentsImpl(true)}'
-        '($mapType json) {\n');
+        '($mapType json');
+
+    if (config.genericArgumentFactories) {
+      for (var arg in element.typeParameters) {
+        final helperName = helperForType(
+          arg.instantiate(nullabilitySuffix: NullabilitySuffix.none),
+        );
+
+        buffer.write(', ${arg.name} Function(Object json) $helperName');
+      }
+      if (element.typeParameters.isNotEmpty) {
+        buffer.write(',');
+      }
+    }
+
+    buffer.write(') {\n');
 
     String deserializeFun(String paramOrFieldName,
             {ParameterElement ctorParam}) =>

--- a/json_serializable/lib/src/encoder_helper.dart
+++ b/json_serializable/lib/src/encoder_helper.dart
@@ -3,10 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 import 'constants.dart';
 import 'helper_core.dart';
+import 'type_helpers/generic_factory_helper.dart';
 import 'type_helpers/json_converter_helper.dart';
 import 'unsupported_type_error.dart';
 
@@ -20,7 +22,20 @@ abstract class EncodeHelper implements HelperCore {
 
     final functionName = '${prefix}ToJson${genericClassArgumentsImpl(true)}';
     buffer.write('Map<String, dynamic> '
-        '$functionName($targetClassReference $_toJsonParamName) ');
+        '$functionName($targetClassReference $_toJsonParamName');
+
+    if (config.genericArgumentFactories) {
+      for (var arg in element.typeParameters) {
+        final helperName = helperForType(
+          arg.instantiate(nullabilitySuffix: NullabilitySuffix.none),
+        );
+        buffer.write(',Object Function(${arg.name} value) $helperName');
+      }
+      if (element.typeParameters.isNotEmpty) {
+        buffer.write(',');
+      }
+    }
+    buffer.write(') ');
 
     final writeNaive = accessibleFields.every(_writeJsonValueNaive);
 

--- a/json_serializable/lib/src/type_helpers/generic_factory_helper.dart
+++ b/json_serializable/lib/src/type_helpers/generic_factory_helper.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/element/type.dart';
+
+import '../lambda_result.dart';
+import '../type_helper.dart';
+
+class GenericFactoryHelper extends TypeHelper<TypeHelperContextWithConfig> {
+  const GenericFactoryHelper();
+
+  @override
+  Object serialize(
+    DartType targetType,
+    String expression,
+    TypeHelperContextWithConfig context,
+  ) =>
+      deserialize(targetType, expression, context);
+
+  @override
+  Object deserialize(
+    DartType targetType,
+    String expression,
+    TypeHelperContextWithConfig context,
+  ) {
+    if (targetType is TypeParameterType) {
+      if (context.config.genericArgumentFactories) {
+        return LambdaResult(expression, helperForType(targetType));
+      }
+    }
+
+    return null;
+  }
+}
+
+String helperForType(TypeParameterType type) =>
+    helperForName(type.getDisplayString());
+
+String helperForName(String genericType) => 'helperFor$genericType';

--- a/json_serializable/lib/src/type_helpers/json_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_helper.dart
@@ -139,7 +139,11 @@ JsonSerializable _annotation(JsonSerializable config, InterfaceType source) {
     return null;
   }
 
-  return mergeConfig(config, ConstantReader(annotations.single));
+  return mergeConfig(
+    config,
+    ConstantReader(annotations.single),
+    classElement: source.element,
+  );
 }
 
 MethodElement _toJsonMethod(DartType type) => typeImplementations(type)

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 3.4.2-dev
+version: 3.5.0-dev
 description: >-
   Automatically generate code for converting to and from JSON by annotating
   Dart classes.
@@ -16,7 +16,7 @@ dependencies:
   # `json_annotation` properly constrains all features it provides.
   # For v3 only – allow a wide range since the only change was to REMOVE things
   # from json_annotation
-  json_annotation: '>=3.0.0 <3.1.0'
+  json_annotation: '>=3.1.0 <3.2.0'
   meta: ^1.1.0
   path: ^1.3.2
   source_gen: ^0.9.6
@@ -32,3 +32,7 @@ dev_dependencies:
   source_gen_test: ^0.1.0
   test: ^1.6.0
   yaml: ^2.1.13
+
+dependency_overrides:
+  json_annotation:
+    path: ../json_annotation

--- a/json_serializable/test/config_test.dart
+++ b/json_serializable/test/config_test.dart
@@ -139,6 +139,7 @@ const _invalidConfig = {
   'disallow_unrecognized_keys': 42,
   'explicit_to_json': 42,
   'field_rename': 42,
+  'generic_argument_factories': 42,
   'ignore_unannotated': 42,
   'include_if_null': 42,
   'nullable': 42,

--- a/json_serializable/test/generic_files/generic_argument_factories.dart
+++ b/json_serializable/test/generic_files/generic_argument_factories.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:json_annotation/json_annotation.dart';
+
+part 'generic_argument_factories.g.dart';
+
+@JsonSerializable(genericArgumentFactories: true)
+class GenericClassWithHelpers<T, S> {
+  final T value;
+
+  final List<T> list;
+
+  final Set<S> someSet;
+
+  GenericClassWithHelpers(
+    this.value,
+    this.list,
+    this.someSet,
+  );
+
+  factory GenericClassWithHelpers.fromJson(
+    Map<String, dynamic> json,
+    T Function(Object json) helperForT,
+    S Function(Object json) helperForS,
+  ) =>
+      _$GenericClassWithHelpersFromJson(json, helperForT, helperForS);
+
+  Map<String, dynamic> toJson(
+    Object Function(T value) helperForT,
+    Object Function(S value) helperForS,
+  ) =>
+      _$GenericClassWithHelpersToJson(this, helperForT, helperForS);
+}

--- a/json_serializable/test/generic_files/generic_argument_factories.g.dart
+++ b/json_serializable/test/generic_files/generic_argument_factories.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'generic_argument_factories.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+GenericClassWithHelpers<T, S> _$GenericClassWithHelpersFromJson<T, S>(
+  Map<String, dynamic> json,
+  T Function(Object json) helperForT,
+  S Function(Object json) helperForS,
+) {
+  return GenericClassWithHelpers<T, S>(
+    helperForT(json['value']),
+    (json['list'] as List)?.map(helperForT)?.toList(),
+    (json['someSet'] as List)?.map(helperForS)?.toSet(),
+  );
+}
+
+Map<String, dynamic> _$GenericClassWithHelpersToJson<T, S>(
+  GenericClassWithHelpers<T, S> instance,
+  Object Function(T value) helperForT,
+  Object Function(S value) helperForS,
+) =>
+    <String, dynamic>{
+      'value': helperForT(instance.value),
+      'list': instance.list?.map(helperForT)?.toList(),
+      'someSet': instance.someSet?.map(helperForS)?.toList(),
+    };

--- a/json_serializable/test/generic_files/generic_test.dart
+++ b/json_serializable/test/generic_files/generic_test.dart
@@ -3,9 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
+
 import 'package:test/test.dart';
 
 import '../test_utils.dart';
+import 'generic_argument_factories.dart';
 import 'generic_class.dart';
 
 void main() {
@@ -47,6 +49,38 @@ void main() {
           () =>
               GenericClass<double, String>()..fieldS = (5 as dynamic) as String,
           throwsCastError);
+    });
+  });
+
+  group('genericArgumentFactories', () {
+    test('basic round-trip', () {
+      final instance = GenericClassWithHelpers<DateTime, Duration>(
+        DateTime.fromMillisecondsSinceEpoch(0).toUtc(),
+        [
+          DateTime.fromMillisecondsSinceEpoch(1).toUtc(),
+          DateTime.fromMillisecondsSinceEpoch(2).toUtc(),
+        ],
+        {const Duration(milliseconds: 3), const Duration(milliseconds: 4)},
+      );
+
+      String encodeDateTime(DateTime value) => value?.toIso8601String();
+      int encodeDuration(Duration value) => value.inMilliseconds;
+
+      final encodedJson = loudEncode(
+        instance.toJson(encodeDateTime, encodeDuration),
+      );
+
+      final decoded = GenericClassWithHelpers<DateTime, Duration>.fromJson(
+        jsonDecode(encodedJson) as Map<String, dynamic>,
+        (value) => DateTime.parse(value as String),
+        (value) => Duration(milliseconds: value as int),
+      );
+
+      final encodedJson2 = loudEncode(
+        decoded.toJson(encodeDateTime, encodeDuration),
+      );
+
+      expect(encodedJson2, encodedJson);
     });
   });
 }

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -51,6 +51,7 @@ const _expectedAnnotatedTests = [
   'FromDynamicCollection',
   'GeneralTestClass1',
   'GeneralTestClass2',
+  'GenericArgumentFactoriesFlagWithoutGenericType',
   'GenericClass',
   'IgnoredFieldClass',
   'IgnoredFieldCtorClass',

--- a/json_serializable/test/shared_config.dart
+++ b/json_serializable/test/shared_config.dart
@@ -21,4 +21,5 @@ final generatorConfigNonDefaultJson =
   ignoreUnannotated: true,
   includeIfNull: false,
   nullable: false,
+  genericArgumentFactories: true,
 ).toJson());

--- a/json_serializable/test/src/generic_test_input.dart
+++ b/json_serializable/test/src/generic_test_input.dart
@@ -48,3 +48,26 @@ class GenericClass<T extends num, S> {
 T _dataFromJson<T extends num>(Object input) => null;
 
 Object _dataToJson<T extends num>(T input) => null;
+
+@ShouldGenerate(
+  r'''
+GenericArgumentFactoriesFlagWithoutGenericType
+    _$GenericArgumentFactoriesFlagWithoutGenericTypeFromJson(
+        Map<String, dynamic> json) {
+  return GenericArgumentFactoriesFlagWithoutGenericType();
+}
+
+Map<String, dynamic> _$GenericArgumentFactoriesFlagWithoutGenericTypeToJson(
+        GenericArgumentFactoriesFlagWithoutGenericType instance) =>
+    <String, dynamic>{};
+''',
+  expectedLogItems: [
+    'The class `GenericArgumentFactoriesFlagWithoutGenericType` is annotated '
+        'with `JsonSerializable` field `genericArgumentFactories: true`. '
+        '`genericArgumentFactories: true` only affects classes with type '
+        'parameters. For classes without type parameters, the option is '
+        'ignored.',
+  ],
+)
+@JsonSerializable(genericArgumentFactories: true)
+class GenericArgumentFactoriesFlagWithoutGenericType {}

--- a/json_serializable/test/test_sources/test_sources.dart
+++ b/json_serializable/test/test_sources/test_sources.dart
@@ -16,6 +16,7 @@ class ConfigurationImplicitDefaults {
   ignoreUnannotated: false,
   includeIfNull: true,
   nullable: true,
+  genericArgumentFactories: false,
 )
 class ConfigurationExplicitDefaults {
   int field;


### PR DESCRIPTION
When `true` on classes with type parameters (generic types), extra
"helper" parameters will be generated for `fromJson` and/or `toJson` to
support serializing values of those types.

For example, the generated code for

```dart
@JsonSerializable(genericArgumentFactories: true)
class Response<T> {
  int status;
  T value;
}

```

Looks like

```dart
Response<T> _$ResponseFromJson<T>(
  Map<String, dynamic> json,
  T Function(Object json) helperForT,
) {
  return Response<T>()
    ..status = json['status'] as int
    ..value = helperForT(json['value']);
}
Map<String, dynamic> _$ResponseToJson<T>(
  Response<T> instance,
  Object Function(T value) helperForT,
) =>
    <String, dynamic>{
      'status': instance.status,
      'value': helperForT(instance.value),
    };
```

Note: this option has no effect on classes class without type parameters.
A warning is printed in such cases.

Note: if this option is set for all classes in a package via `build.yaml`
it is only applied to classes with type parameters – so no warning is
printed.

Related to https://github.com/google/json_serializable.dart/issues/593 https://github.com/google/json_serializable.dart/issues/599 https://github.com/google/json_serializable.dart/issues/646 https://github.com/google/json_serializable.dart/issues/671