### PR TITLE
Improve error message when @JsonSerializable is used with generics

### DIFF
--- a/json_serializable/lib/src/json_serializable_generator.dart
+++ b/json_serializable/lib/src/json_serializable_generator.dart
@@ -88,10 +88,10 @@ class JsonSerializableGenerator
     BuildStep buildStep,
   ) {
     if (element is! ClassElement) {
-      final name = element.name;
-      throw InvalidGenerationSourceError('Generator cannot target `$name`.',
-          todo: 'Remove the JsonSerializable annotation from `$name`.',
-          element: element);
+      throw InvalidGenerationSourceError(
+        '`@JsonSerializable` can only be used on classes.',
+        element: element,
+      );
     }
 
     final classElement = element as ClassElement;
@@ -186,9 +186,9 @@ class _GeneratorHelper extends HelperCore with EncodeHelper, DecodeHelper {
         final jsonKey = nameAccess(fe);
         if (!set.add(jsonKey)) {
           throw InvalidGenerationSourceError(
-              'More than one field has the JSON key `$jsonKey`.',
-              todo: 'Check the `JsonKey` annotations on fields.',
-              element: fe);
+            'More than one field has the JSON key for name "$jsonKey".',
+            element: fe,
+          );
         }
         return set;
       },

--- a/json_serializable/test/src/_json_serializable_test_input.dart
+++ b/json_serializable/test/src/_json_serializable_test_input.dart
@@ -29,13 +29,11 @@ part 'to_from_json_test_input.dart';
 
 part 'unknown_enum_value_test_input.dart';
 
-@ShouldThrow('Generator cannot target `theAnswer`.',
-    todo: 'Remove the JsonSerializable annotation from `theAnswer`.')
+@ShouldThrow('`@JsonSerializable` can only be used on classes.')
 @JsonSerializable()
 const theAnswer = 42;
 
-@ShouldThrow('Generator cannot target `annotatedMethod`.',
-    todo: 'Remove the JsonSerializable annotation from `annotatedMethod`.')
+@ShouldThrow('`@JsonSerializable` can only be used on classes.')
 @JsonSerializable()
 Object annotatedMethod() => null;
 
@@ -271,8 +269,7 @@ class NoCtorClass {
 }
 
 @ShouldThrow(
-  'More than one field has the JSON key `str`.',
-  todo: 'Check the `JsonKey` annotations on fields.',
+  'More than one field has the JSON key for name "str".',
   element: 'str',
 )
 @JsonSerializable(createFactory: false)
@@ -284,8 +281,7 @@ class KeyDupesField {
 }
 
 @ShouldThrow(
-  'More than one field has the JSON key `a`.',
-  todo: 'Check the `JsonKey` annotations on fields.',
+  'More than one field has the JSON key for name "a".',
   element: 'str',
 )
 @JsonSerializable(createFactory: false)

--- a/json_serializable/test/src/core_subclass_type_input.dart
+++ b/json_serializable/test/src/core_subclass_type_input.dart
@@ -4,7 +4,6 @@ part of '_json_serializable_test_input.dart';
   r'''
 Could not generate `fromJson` code for `mapView`.
 None of the provided `TypeHelper` instances support the defined type.''',
-  todo: 'Make sure all of the types are serializable.',
   element: 'mapView',
 )
 @JsonSerializable(createToJson: false)
@@ -16,7 +15,6 @@ class UnsupportedMapField {
   r'''
 Could not generate `fromJson` code for `listView`.
 None of the provided `TypeHelper` instances support the defined type.''',
-  todo: 'Make sure all of the types are serializable.',
   element: 'listView',
 )
 @JsonSerializable(createToJson: false)
@@ -28,7 +26,6 @@ class UnsupportedListField {
   r'''
 Could not generate `fromJson` code for `customSet`.
 None of the provided `TypeHelper` instances support the defined type.''',
-  todo: 'Make sure all of the types are serializable.',
   element: 'customSet',
 )
 @JsonSerializable(createToJson: false)
@@ -42,7 +39,6 @@ abstract class _CustomSet implements Set {}
   r'''
 Could not generate `fromJson` code for `customDuration`.
 None of the provided `TypeHelper` instances support the defined type.''',
-  todo: 'Make sure all of the types are serializable.',
   element: 'customDuration',
 )
 @JsonSerializable(createToJson: false)
@@ -56,7 +52,6 @@ abstract class _CustomDuration implements Duration {}
   r'''
 Could not generate `fromJson` code for `customUri`.
 None of the provided `TypeHelper` instances support the defined type.''',
-  todo: 'Make sure all of the types are serializable.',
   element: 'customUri',
 )
 @JsonSerializable(createToJson: false)
@@ -70,7 +65,6 @@ abstract class _CustomUri implements Uri {}
   r'''
 Could not generate `fromJson` code for `customDateTime`.
 None of the provided `TypeHelper` instances support the defined type.''',
-  todo: 'Make sure all of the types are serializable.',
   element: 'customDateTime',
 )
 @JsonSerializable(createToJson: false)

--- a/json_serializable/test/src/generic_test_input.dart
+++ b/json_serializable/test/src/generic_test_input.dart
@@ -5,9 +5,18 @@
 part of '_json_serializable_test_input.dart';
 
 @ShouldThrow(
-  'Could not generate `fromJson` code for `result` because of type '
-  '`TResult (type parameter)`.\n'
-  'None of the provided `TypeHelper` instances support the defined type.',
+  r'''
+Could not generate `fromJson` code for `result` because of type `TResult` (type parameter).
+None of the provided `TypeHelper` instances support the defined type.
+To support type paramaters (generic types) you can:
+1) Use `JsonConverter`
+  https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonConverter-class.html
+2) Use `JsonKey` fields `fromJson` and `toJson`
+  https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/fromJson.html
+  https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/toJson.html
+3) Set `JsonSerializable.genericArgumentFactories` to `true`
+  https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/genericArgumentFactories.html''',
+  element: 'result',
 )
 @JsonSerializable()
 class Issue713<TResult> {


### PR DESCRIPTION
Follow-up on https://github.com/google/json_serializable.dart/pull/714

Also drop use of `InvalidGenerationSourceError.todo`

See https://github.com/dart-lang/source_gen/issues/480