### PR TITLE
support operator equal and hashcode 1

### DIFF
--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -174,6 +174,24 @@ class JsonSerializable {
   /// `includeIfNull`, that value takes precedent.
   final bool? includeIfNull;
 
+  /// When `true` , a private, static `_$ExampleEqual` method
+  /// is created in the generated part file.
+  ///
+  /// Call this method from a factory constructor added to the source class:
+  ///
+  /// ```dart
+  /// import 'dart:ui';
+  ///
+  /// @JsonSerializable()
+  /// class Example {
+  ///   // ...
+  ///   bool operator ==(dynamic other) => _$ExampleEqual(this, other);
+  ///
+  ///   int get hashCode => _$ExampleHashCode(this);
+  /// }
+  /// ```
+  // final bool? createEqual;
+
   /// Creates a new [JsonSerializable] instance.
   const JsonSerializable({
     @Deprecated('Has no effect') bool? nullable,

--- a/json_serializable/lib/src/equal_helper.dart
+++ b/json_serializable/lib/src/equal_helper.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/element/element.dart';
+
+import 'helper_core.dart';
+
+abstract class EqualHelper implements HelperCore {
+  String _fieldInstanceAccess(FieldElement field) => '$_instance.${field.name}';
+  String _fieldOtherAccess(FieldElement field) => '$_other.${field.name}';
+
+  Iterable<String> createEqual(Set<FieldElement> accessibleFields) sync* {
+    // assert(config.createEqual);
+
+    final buffer = StringBuffer();
+
+    final functionName = '${prefix}IsEqual${genericClassArgumentsImpl(true)}';
+    buffer
+      ..write('bool '
+          '$functionName($targetClassReference $_instance, dynamic $_other')
+      ..write(') {\n');
+
+    _writeOperatorToJsonSimple(buffer, accessibleFields);
+
+    _writeHashCodeToJson(buffer, accessibleFields);
+
+    yield buffer.toString();
+  }
+
+  void _writeOperatorToJsonSimple(
+      StringBuffer buffer, Iterable<FieldElement> fields) {
+    buffer
+      ..write('return other is $targetClassReference')
+      ..writeAll(fields.map((field) {
+        final value =
+            '${_fieldInstanceAccess(field)} == ${_fieldOtherAccess(field)}';
+        return '        && $value\n';
+      }))
+      ..write(';')
+      ..writeln('}');
+  }
+
+  void _writeHashCodeToJson(
+      StringBuffer buffer, Iterable<FieldElement> fields) {
+    buffer
+      ..write(
+          'int ${prefix}HashCode($targetClassReference $_instance) => hashList(<Object?>[')
+      ..writeAll(fields.map((field) {
+        return '        ${_fieldInstanceAccess(field)},\n';
+      }))
+      ..writeln(']);');
+  }
+
+  static const _instance = 'instance';
+  static const _other = 'other';
+}

--- a/json_serializable/lib/src/generator_helper.dart
+++ b/json_serializable/lib/src/generator_helper.dart
@@ -115,7 +115,7 @@ class GeneratorHelper extends HelperCore
     }
 
     // if (config.createEqual) {
-      yield* createEqual(accessibleFieldSet);
+    yield* createEqual(accessibleFieldSet);
     // }
 
     yield* _addedMembers;

--- a/json_serializable/lib/src/generator_helper.dart
+++ b/json_serializable/lib/src/generator_helper.dart
@@ -8,13 +8,15 @@ import 'package:source_gen/source_gen.dart';
 
 import 'decode_helper.dart';
 import 'encoder_helper.dart';
+import 'equal_helper.dart';
 import 'field_helpers.dart';
 import 'helper_core.dart';
 import 'settings.dart';
 import 'type_helper.dart';
 import 'utils.dart';
 
-class GeneratorHelper extends HelperCore with EncodeHelper, DecodeHelper {
+class GeneratorHelper extends HelperCore
+    with EncodeHelper, DecodeHelper, EqualHelper {
   final Settings _generator;
   final _addedMembers = <String>{};
 
@@ -111,6 +113,10 @@ class GeneratorHelper extends HelperCore with EncodeHelper, DecodeHelper {
     if (config.createToJson) {
       yield* createToJson(accessibleFieldSet);
     }
+
+    // if (config.createEqual) {
+      yield* createEqual(accessibleFieldSet);
+    // }
 
     yield* _addedMembers;
   }


### PR DESCRIPTION
When I use provider with json_serializable, I think json_serializable should support auto create 'operator ==' for every field.
So I push this pr. Is it just not used or there are other reasons for this?
I can't add a new params because of the html documentation, so can anybody help me to add a 'createEqual' param?