### PR TITLE
Serialise dates to UTC

### DIFF
--- a/json_serializable/example/example.g.dart
+++ b/json_serializable/example/example.g.dart
@@ -20,5 +20,5 @@ Person _$PersonFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$PersonToJson(Person instance) => <String, dynamic>{
       'firstName': instance.firstName,
       'lastName': instance.lastName,
-      'dateOfBirth': instance.dateOfBirth?.toUtc()?.toIso8601String(),
+      'dateOfBirth': instance.dateOfBirth?.toUtc().toIso8601String(),
     };

--- a/json_serializable/example/example.g.dart
+++ b/json_serializable/example/example.g.dart
@@ -20,5 +20,5 @@ Person _$PersonFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$PersonToJson(Person instance) => <String, dynamic>{
       'firstName': instance.firstName,
       'lastName': instance.lastName,
-      'dateOfBirth': instance.dateOfBirth?.toIso8601String(),
+      'dateOfBirth': instance.dateOfBirth?.toUtc()?.toIso8601String(),
     };

--- a/json_serializable/lib/src/type_helpers/to_from_string.dart
+++ b/json_serializable/lib/src/type_helpers/to_from_string.dart
@@ -15,7 +15,7 @@ final bigIntString = ToFromStringHelper(
 
 final dateTimeString = ToFromStringHelper(
   'DateTime.parse',
-  'toIso8601String()',
+  'toUtc().toIso8601String()',
   'DateTime',
 );
 
@@ -57,11 +57,13 @@ class ToFromStringHelper {
       return null;
     }
 
+    var toString = _toString;
     if (nullable) {
+      toString = toString.replaceAll('.', '?.');
       expression = '$expression?';
     }
 
-    return '$expression.$_toString';
+    return '$expression.$toString';
   }
 
   String deserialize(

--- a/json_serializable/lib/src/type_helpers/to_from_string.dart
+++ b/json_serializable/lib/src/type_helpers/to_from_string.dart
@@ -57,13 +57,11 @@ class ToFromStringHelper {
       return null;
     }
 
-    var toString = _toString;
     if (nullable) {
-      toString = toString.replaceAll('.', '?.');
       expression = '$expression?';
     }
 
-    return '$expression.$toString';
+    return '$expression.$_toString';
   }
 
   String deserialize(

--- a/json_serializable/test/integration/json_test_example.g.dart
+++ b/json_serializable/test/integration/json_test_example.g.dart
@@ -37,7 +37,7 @@ Map<String, dynamic> _$PersonToJson(Person instance) => <String, dynamic>{
       'firstName': instance.firstName,
       'lastName': instance.lastName,
       'middleName': instance.middleName,
-      'dateOfBirth': instance.dateOfBirth?.toIso8601String(),
+      'dateOfBirth': instance.dateOfBirth?.toUtc()?.toIso8601String(),
       r'$house': _$CategoryEnumMap[instance.house],
       'order': instance.order,
       'customOrders': instance.customOrders,
@@ -172,7 +172,7 @@ Map<String, dynamic> _$ItemToJson(Item instance) {
 
   writeNotNull('item-number', instance.itemNumber);
   val['saleDates'] =
-      instance.saleDates?.map((e) => e.toIso8601String()).toList();
+      instance.saleDates?.map((e) => e.toUtc().toIso8601String()).toList();
   val['rates'] = instance.rates;
   return val;
 }
@@ -221,7 +221,7 @@ Map<String, dynamic> _$MapKeyVarietyToJson(MapKeyVariety instance) =>
       'intIntMap': instance.intIntMap?.map((k, e) => MapEntry(k.toString(), e)),
       'uriIntMap': instance.uriIntMap?.map((k, e) => MapEntry(k.toString(), e)),
       'dateTimeIntMap': instance.dateTimeIntMap
-          ?.map((k, e) => MapEntry(k.toIso8601String(), e)),
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
       'bigIntMap': instance.bigIntMap?.map((k, e) => MapEntry(k.toString(), e)),
     };
 

--- a/json_serializable/test/integration/json_test_example.g.dart
+++ b/json_serializable/test/integration/json_test_example.g.dart
@@ -37,7 +37,7 @@ Map<String, dynamic> _$PersonToJson(Person instance) => <String, dynamic>{
       'firstName': instance.firstName,
       'lastName': instance.lastName,
       'middleName': instance.middleName,
-      'dateOfBirth': instance.dateOfBirth?.toUtc()?.toIso8601String(),
+      'dateOfBirth': instance.dateOfBirth?.toUtc().toIso8601String(),
       r'$house': _$CategoryEnumMap[instance.house],
       'order': instance.order,
       'customOrders': instance.customOrders,

--- a/json_serializable/test/integration/json_test_example.g_any_map.g.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.g.dart
@@ -37,7 +37,7 @@ Map<String, dynamic> _$PersonToJson(Person instance) => <String, dynamic>{
       'firstName': instance.firstName,
       'lastName': instance.lastName,
       'middleName': instance.middleName,
-      'dateOfBirth': instance.dateOfBirth?.toIso8601String(),
+      'dateOfBirth': instance.dateOfBirth?.toUtc()?.toIso8601String(),
       r'$house': _$CategoryEnumMap[instance.house],
       'order': instance.order,
       'customOrders': instance.customOrders,
@@ -172,7 +172,7 @@ Map<String, dynamic> _$ItemToJson(Item instance) {
 
   writeNotNull('item-number', instance.itemNumber);
   val['saleDates'] =
-      instance.saleDates?.map((e) => e.toIso8601String()).toList();
+      instance.saleDates?.map((e) => e.toUtc().toIso8601String()).toList();
   val['rates'] = instance.rates;
   return val;
 }
@@ -221,7 +221,7 @@ Map<String, dynamic> _$MapKeyVarietyToJson(MapKeyVariety instance) =>
       'intIntMap': instance.intIntMap?.map((k, e) => MapEntry(k.toString(), e)),
       'uriIntMap': instance.uriIntMap?.map((k, e) => MapEntry(k.toString(), e)),
       'dateTimeIntMap': instance.dateTimeIntMap
-          ?.map((k, e) => MapEntry(k.toIso8601String(), e)),
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
       'bigIntMap': instance.bigIntMap?.map((k, e) => MapEntry(k.toString(), e)),
     };
 

--- a/json_serializable/test/integration/json_test_example.g_any_map.g.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.g.dart
@@ -37,7 +37,7 @@ Map<String, dynamic> _$PersonToJson(Person instance) => <String, dynamic>{
       'firstName': instance.firstName,
       'lastName': instance.lastName,
       'middleName': instance.middleName,
-      'dateOfBirth': instance.dateOfBirth?.toUtc()?.toIso8601String(),
+      'dateOfBirth': instance.dateOfBirth?.toUtc().toIso8601String(),
       r'$house': _$CategoryEnumMap[instance.house],
       'order': instance.order,
       'customOrders': instance.customOrders,

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
@@ -74,7 +74,7 @@ KitchenSink _$KitchenSinkFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
     <String, dynamic>{
       'no-42': instance.ctorValidatedNo42,
-      'dateTime': instance.dateTime?.toUtc()?.toIso8601String(),
+      'dateTime': instance.dateTime?.toUtc().toIso8601String(),
       'bigInt': instance.bigInt?.toString(),
       'iterable': instance.iterable?.toList(),
       'dynamicIterable': instance.dynamicIterable.toList(),

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
@@ -74,7 +74,7 @@ KitchenSink _$KitchenSinkFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
     <String, dynamic>{
       'no-42': instance.ctorValidatedNo42,
-      'dateTime': instance.dateTime?.toIso8601String(),
+      'dateTime': instance.dateTime?.toUtc()?.toIso8601String(),
       'bigInt': instance.bigInt?.toString(),
       'iterable': instance.iterable?.toList(),
       'dynamicIterable': instance.dynamicIterable.toList(),
@@ -85,27 +85,27 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
       'objectSet': instance.objectSet.toList(),
       'intSet': instance.intSet.toList(),
       'dateTimeSet':
-          instance.dateTimeSet.map((e) => e.toIso8601String()).toList(),
+          instance.dateTimeSet.map((e) => e.toUtc().toIso8601String()).toList(),
       'datetime-iterable':
-          instance.dateTimeIterable.map((e) => e.toIso8601String()).toList(),
+          instance.dateTimeIterable.map((e) => e.toUtc().toIso8601String()).toList(),
       'list': instance.list,
       'dynamicList': instance.dynamicList,
       'objectList': instance.objectList,
       'intList': instance.intList,
       'dateTimeList':
-          instance.dateTimeList.map((e) => e.toIso8601String()).toList(),
+          instance.dateTimeList.map((e) => e.toUtc().toIso8601String()).toList(),
       'map': instance.map,
       'stringStringMap': instance.stringStringMap,
       'dynamicIntMap': instance.dynamicIntMap,
       'objectDateTimeMap': instance.objectDateTimeMap
-          .map((k, e) => MapEntry(k, e.toIso8601String())),
+          .map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
       'crazyComplex': instance.crazyComplex
           .map((e) => e?.map((k, e) => MapEntry(
               k,
               e?.map((k, e) => MapEntry(
                   k,
                   e
-                      ?.map((e) => e?.map((e) => e.toIso8601String()).toList())
+                      ?.map((e) => e?.map((e) => e.toUtc().toIso8601String()).toList())
                       .toList())))))
           .toList(),
       'val': instance.val,

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
@@ -86,14 +86,16 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
       'intSet': instance.intSet.toList(),
       'dateTimeSet':
           instance.dateTimeSet.map((e) => e.toUtc().toIso8601String()).toList(),
-      'datetime-iterable':
-          instance.dateTimeIterable.map((e) => e.toUtc().toIso8601String()).toList(),
+      'datetime-iterable': instance.dateTimeIterable
+          .map((e) => e.toUtc().toIso8601String())
+          .toList(),
       'list': instance.list,
       'dynamicList': instance.dynamicList,
       'objectList': instance.objectList,
       'intList': instance.intList,
-      'dateTimeList':
-          instance.dateTimeList.map((e) => e.toUtc().toIso8601String()).toList(),
+      'dateTimeList': instance.dateTimeList
+          .map((e) => e.toUtc().toIso8601String())
+          .toList(),
       'map': instance.map,
       'stringStringMap': instance.stringStringMap,
       'dynamicIntMap': instance.dynamicIntMap,
@@ -105,7 +107,8 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
               e?.map((k, e) => MapEntry(
                   k,
                   e
-                      ?.map((e) => e?.map((e) => e.toUtc().toIso8601String()).toList())
+                      ?.map((e) =>
+                          e?.map((e) => e.toUtc().toIso8601String()).toList())
                       .toList())))))
           .toList(),
       'val': instance.val,

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map.g.dart
@@ -84,14 +84,16 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
       'intSet': instance.intSet.toList(),
       'dateTimeSet':
           instance.dateTimeSet.map((e) => e.toUtc().toIso8601String()).toList(),
-      'datetime-iterable':
-          instance.dateTimeIterable.map((e) => e.toUtc().toIso8601String()).toList(),
+      'datetime-iterable': instance.dateTimeIterable
+          .map((e) => e.toUtc().toIso8601String())
+          .toList(),
       'list': instance.list,
       'dynamicList': instance.dynamicList,
       'objectList': instance.objectList,
       'intList': instance.intList,
-      'dateTimeList':
-          instance.dateTimeList.map((e) => e.toUtc().toIso8601String()).toList(),
+      'dateTimeList': instance.dateTimeList
+          .map((e) => e.toUtc().toIso8601String())
+          .toList(),
       'map': instance.map,
       'stringStringMap': instance.stringStringMap,
       'dynamicIntMap': instance.dynamicIntMap,
@@ -103,7 +105,8 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
               e?.map((k, e) => MapEntry(
                   k,
                   e
-                      ?.map((e) => e?.map((e) => e.toUtc().toIso8601String()).toList())
+                      ?.map((e) =>
+                          e?.map((e) => e.toUtc().toIso8601String()).toList())
                       .toList())))))
           .toList(),
       'val': instance.val,

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map.g.dart
@@ -72,7 +72,7 @@ KitchenSink _$KitchenSinkFromJson(Map json) {
 Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
     <String, dynamic>{
       'no-42': instance.ctorValidatedNo42,
-      'dateTime': instance.dateTime?.toUtc()?.toIso8601String(),
+      'dateTime': instance.dateTime?.toUtc().toIso8601String(),
       'bigInt': instance.bigInt?.toString(),
       'iterable': instance.iterable?.toList(),
       'dynamicIterable': instance.dynamicIterable.toList(),

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map.g.dart
@@ -72,7 +72,7 @@ KitchenSink _$KitchenSinkFromJson(Map json) {
 Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
     <String, dynamic>{
       'no-42': instance.ctorValidatedNo42,
-      'dateTime': instance.dateTime?.toIso8601String(),
+      'dateTime': instance.dateTime?.toUtc()?.toIso8601String(),
       'bigInt': instance.bigInt?.toString(),
       'iterable': instance.iterable?.toList(),
       'dynamicIterable': instance.dynamicIterable.toList(),
@@ -83,27 +83,27 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
       'objectSet': instance.objectSet.toList(),
       'intSet': instance.intSet.toList(),
       'dateTimeSet':
-          instance.dateTimeSet.map((e) => e.toIso8601String()).toList(),
+          instance.dateTimeSet.map((e) => e.toUtc().toIso8601String()).toList(),
       'datetime-iterable':
-          instance.dateTimeIterable.map((e) => e.toIso8601String()).toList(),
+          instance.dateTimeIterable.map((e) => e.toUtc().toIso8601String()).toList(),
       'list': instance.list,
       'dynamicList': instance.dynamicList,
       'objectList': instance.objectList,
       'intList': instance.intList,
       'dateTimeList':
-          instance.dateTimeList.map((e) => e.toIso8601String()).toList(),
+          instance.dateTimeList.map((e) => e.toUtc().toIso8601String()).toList(),
       'map': instance.map,
       'stringStringMap': instance.stringStringMap,
       'dynamicIntMap': instance.dynamicIntMap,
       'objectDateTimeMap': instance.objectDateTimeMap
-          .map((k, e) => MapEntry(k, e.toIso8601String())),
+          .map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
       'crazyComplex': instance.crazyComplex
           .map((e) => e?.map((k, e) => MapEntry(
               k,
               e?.map((k, e) => MapEntry(
                   k,
                   e
-                      ?.map((e) => e?.map((e) => e.toIso8601String()).toList())
+                      ?.map((e) => e?.map((e) => e.toUtc().toIso8601String()).toList())
                       .toList())))))
           .toList(),
       'val': instance.val,

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map__checked.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map__checked.g.dart
@@ -125,14 +125,16 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
       'intSet': instance.intSet.toList(),
       'dateTimeSet':
           instance.dateTimeSet.map((e) => e.toUtc().toIso8601String()).toList(),
-      'datetime-iterable':
-          instance.dateTimeIterable.map((e) => e.toUtc().toIso8601String()).toList(),
+      'datetime-iterable': instance.dateTimeIterable
+          .map((e) => e.toUtc().toIso8601String())
+          .toList(),
       'list': instance.list,
       'dynamicList': instance.dynamicList,
       'objectList': instance.objectList,
       'intList': instance.intList,
-      'dateTimeList':
-          instance.dateTimeList.map((e) => e.toUtc().toIso8601String()).toList(),
+      'dateTimeList': instance.dateTimeList
+          .map((e) => e.toUtc().toIso8601String())
+          .toList(),
       'map': instance.map,
       'stringStringMap': instance.stringStringMap,
       'dynamicIntMap': instance.dynamicIntMap,
@@ -144,7 +146,8 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
               e?.map((k, e) => MapEntry(
                   k,
                   e
-                      ?.map((e) => e?.map((e) => e.toUtc().toIso8601String()).toList())
+                      ?.map((e) =>
+                          e?.map((e) => e.toUtc().toIso8601String()).toList())
                       .toList())))))
           .toList(),
       'val': instance.val,

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map__checked.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map__checked.g.dart
@@ -113,7 +113,7 @@ KitchenSink _$KitchenSinkFromJson(Map json) {
 Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
     <String, dynamic>{
       'no-42': instance.ctorValidatedNo42,
-      'dateTime': instance.dateTime?.toUtc()?.toIso8601String(),
+      'dateTime': instance.dateTime?.toUtc().toIso8601String(),
       'bigInt': instance.bigInt?.toString(),
       'iterable': instance.iterable?.toList(),
       'dynamicIterable': instance.dynamicIterable.toList(),

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map__checked.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map__checked.g.dart
@@ -113,7 +113,7 @@ KitchenSink _$KitchenSinkFromJson(Map json) {
 Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
     <String, dynamic>{
       'no-42': instance.ctorValidatedNo42,
-      'dateTime': instance.dateTime?.toIso8601String(),
+      'dateTime': instance.dateTime?.toUtc()?.toIso8601String(),
       'bigInt': instance.bigInt?.toString(),
       'iterable': instance.iterable?.toList(),
       'dynamicIterable': instance.dynamicIterable.toList(),
@@ -124,27 +124,27 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
       'objectSet': instance.objectSet.toList(),
       'intSet': instance.intSet.toList(),
       'dateTimeSet':
-          instance.dateTimeSet.map((e) => e.toIso8601String()).toList(),
+          instance.dateTimeSet.map((e) => e.toUtc().toIso8601String()).toList(),
       'datetime-iterable':
-          instance.dateTimeIterable.map((e) => e.toIso8601String()).toList(),
+          instance.dateTimeIterable.map((e) => e.toUtc().toIso8601String()).toList(),
       'list': instance.list,
       'dynamicList': instance.dynamicList,
       'objectList': instance.objectList,
       'intList': instance.intList,
       'dateTimeList':
-          instance.dateTimeList.map((e) => e.toIso8601String()).toList(),
+          instance.dateTimeList.map((e) => e.toUtc().toIso8601String()).toList(),
       'map': instance.map,
       'stringStringMap': instance.stringStringMap,
       'dynamicIntMap': instance.dynamicIntMap,
       'objectDateTimeMap': instance.objectDateTimeMap
-          .map((k, e) => MapEntry(k, e.toIso8601String())),
+          .map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
       'crazyComplex': instance.crazyComplex
           .map((e) => e?.map((k, e) => MapEntry(
               k,
               e?.map((k, e) => MapEntry(
                   k,
                   e
-                      ?.map((e) => e?.map((e) => e.toIso8601String()).toList())
+                      ?.map((e) => e?.map((e) => e.toUtc().toIso8601String()).toList())
                       .toList())))))
           .toList(),
       'val': instance.val,

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_exclude_null.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_exclude_null.g.dart
@@ -93,8 +93,9 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) {
   val['intSet'] = instance.intSet.toList();
   val['dateTimeSet'] =
       instance.dateTimeSet.map((e) => e.toUtc().toIso8601String()).toList();
-  val['datetime-iterable'] =
-      instance.dateTimeIterable.map((e) => e.toUtc().toIso8601String()).toList();
+  val['datetime-iterable'] = instance.dateTimeIterable
+      .map((e) => e.toUtc().toIso8601String())
+      .toList();
   val['list'] = instance.list;
   val['dynamicList'] = instance.dynamicList;
   val['objectList'] = instance.objectList;
@@ -112,7 +113,8 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) {
           e?.map((k, e) => MapEntry(
               k,
               e
-                  ?.map((e) => e?.map((e) => e.toUtc().toIso8601String()).toList())
+                  ?.map((e) =>
+                      e?.map((e) => e.toUtc().toIso8601String()).toList())
                   .toList())))))
       .toList();
   val['val'] = instance.val;

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_exclude_null.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_exclude_null.g.dart
@@ -81,7 +81,7 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) {
   }
 
   writeNotNull('no-42', instance.ctorValidatedNo42);
-  writeNotNull('dateTime', instance.dateTime?.toIso8601String());
+  writeNotNull('dateTime', instance.dateTime?.toUtc()?.toIso8601String());
   writeNotNull('bigInt', instance.bigInt?.toString());
   writeNotNull('iterable', instance.iterable?.toList());
   val['dynamicIterable'] = instance.dynamicIterable.toList();
@@ -92,27 +92,27 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) {
   val['objectSet'] = instance.objectSet.toList();
   val['intSet'] = instance.intSet.toList();
   val['dateTimeSet'] =
-      instance.dateTimeSet.map((e) => e.toIso8601String()).toList();
+      instance.dateTimeSet.map((e) => e.toUtc().toIso8601String()).toList();
   val['datetime-iterable'] =
-      instance.dateTimeIterable.map((e) => e.toIso8601String()).toList();
+      instance.dateTimeIterable.map((e) => e.toUtc().toIso8601String()).toList();
   val['list'] = instance.list;
   val['dynamicList'] = instance.dynamicList;
   val['objectList'] = instance.objectList;
   val['intList'] = instance.intList;
   val['dateTimeList'] =
-      instance.dateTimeList.map((e) => e.toIso8601String()).toList();
+      instance.dateTimeList.map((e) => e.toUtc().toIso8601String()).toList();
   val['map'] = instance.map;
   val['stringStringMap'] = instance.stringStringMap;
   val['dynamicIntMap'] = instance.dynamicIntMap;
   val['objectDateTimeMap'] = instance.objectDateTimeMap
-      .map((k, e) => MapEntry(k, e.toIso8601String()));
+      .map((k, e) => MapEntry(k, e.toUtc().toIso8601String()));
   val['crazyComplex'] = instance.crazyComplex
       .map((e) => e?.map((k, e) => MapEntry(
           k,
           e?.map((k, e) => MapEntry(
               k,
               e
-                  ?.map((e) => e?.map((e) => e.toIso8601String()).toList())
+                  ?.map((e) => e?.map((e) => e.toUtc().toIso8601String()).toList())
                   .toList())))))
       .toList();
   val['val'] = instance.val;

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_exclude_null.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_exclude_null.g.dart
@@ -81,7 +81,7 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) {
   }
 
   writeNotNull('no-42', instance.ctorValidatedNo42);
-  writeNotNull('dateTime', instance.dateTime?.toUtc()?.toIso8601String());
+  writeNotNull('dateTime', instance.dateTime?.toUtc().toIso8601String());
   writeNotNull('bigInt', instance.bigInt?.toString());
   writeNotNull('iterable', instance.iterable?.toList());
   val['dynamicIterable'] = instance.dynamicIterable.toList();

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_explicit_to_json.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_explicit_to_json.g.dart
@@ -74,7 +74,7 @@ KitchenSink _$KitchenSinkFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
     <String, dynamic>{
       'no-42': instance.ctorValidatedNo42,
-      'dateTime': instance.dateTime?.toUtc()?.toIso8601String(),
+      'dateTime': instance.dateTime?.toUtc().toIso8601String(),
       'bigInt': instance.bigInt?.toString(),
       'iterable': instance.iterable?.toList(),
       'dynamicIterable': instance.dynamicIterable.toList(),

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_explicit_to_json.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_explicit_to_json.g.dart
@@ -74,7 +74,7 @@ KitchenSink _$KitchenSinkFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
     <String, dynamic>{
       'no-42': instance.ctorValidatedNo42,
-      'dateTime': instance.dateTime?.toIso8601String(),
+      'dateTime': instance.dateTime?.toUtc()?.toIso8601String(),
       'bigInt': instance.bigInt?.toString(),
       'iterable': instance.iterable?.toList(),
       'dynamicIterable': instance.dynamicIterable.toList(),
@@ -85,27 +85,27 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
       'objectSet': instance.objectSet.toList(),
       'intSet': instance.intSet.toList(),
       'dateTimeSet':
-          instance.dateTimeSet.map((e) => e.toIso8601String()).toList(),
+          instance.dateTimeSet.map((e) => e.toUtc().toIso8601String()).toList(),
       'datetime-iterable':
-          instance.dateTimeIterable.map((e) => e.toIso8601String()).toList(),
+          instance.dateTimeIterable.map((e) => e.toUtc().toIso8601String()).toList(),
       'list': instance.list,
       'dynamicList': instance.dynamicList,
       'objectList': instance.objectList,
       'intList': instance.intList,
       'dateTimeList':
-          instance.dateTimeList.map((e) => e.toIso8601String()).toList(),
+          instance.dateTimeList.map((e) => e.toUtc().toIso8601String()).toList(),
       'map': instance.map,
       'stringStringMap': instance.stringStringMap,
       'dynamicIntMap': instance.dynamicIntMap,
       'objectDateTimeMap': instance.objectDateTimeMap
-          .map((k, e) => MapEntry(k, e.toIso8601String())),
+          .map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
       'crazyComplex': instance.crazyComplex
           .map((e) => e?.map((k, e) => MapEntry(
               k,
               e?.map((k, e) => MapEntry(
                   k,
                   e
-                      ?.map((e) => e?.map((e) => e.toIso8601String()).toList())
+                      ?.map((e) => e?.map((e) => e.toUtc().toIso8601String()).toList())
                       .toList())))))
           .toList(),
       'val': instance.val,

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_explicit_to_json.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_explicit_to_json.g.dart
@@ -86,14 +86,16 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
       'intSet': instance.intSet.toList(),
       'dateTimeSet':
           instance.dateTimeSet.map((e) => e.toUtc().toIso8601String()).toList(),
-      'datetime-iterable':
-          instance.dateTimeIterable.map((e) => e.toUtc().toIso8601String()).toList(),
+      'datetime-iterable': instance.dateTimeIterable
+          .map((e) => e.toUtc().toIso8601String())
+          .toList(),
       'list': instance.list,
       'dynamicList': instance.dynamicList,
       'objectList': instance.objectList,
       'intList': instance.intList,
-      'dateTimeList':
-          instance.dateTimeList.map((e) => e.toUtc().toIso8601String()).toList(),
+      'dateTimeList': instance.dateTimeList
+          .map((e) => e.toUtc().toIso8601String())
+          .toList(),
       'map': instance.map,
       'stringStringMap': instance.stringStringMap,
       'dynamicIntMap': instance.dynamicIntMap,
@@ -105,7 +107,8 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
               e?.map((k, e) => MapEntry(
                   k,
                   e
-                      ?.map((e) => e?.map((e) => e.toUtc().toIso8601String()).toList())
+                      ?.map((e) =>
+                          e?.map((e) => e.toUtc().toIso8601String()).toList())
                       .toList())))))
           .toList(),
       'val': instance.val,

--- a/json_serializable/test/src/_json_serializable_test_input.dart
+++ b/json_serializable/test/src/_json_serializable_test_input.dart
@@ -81,7 +81,7 @@ Map<String, dynamic> _$GeneralTestClass1ToJson(GeneralTestClass1 instance) =>
       'firstName': instance.firstName,
       'lastName': instance.lastName,
       'h': instance.height,
-      'dateOfBirth': instance.dateOfBirth.toIso8601String(),
+      'dateOfBirth': instance.dateOfBirth.toUtc().toIso8601String(),
       'dynamicType': instance.dynamicType,
       'varType': instance.varType,
       'listOfInts': instance.listOfInts,
@@ -114,7 +114,7 @@ Map<String, dynamic> _$GeneralTestClass2ToJson(GeneralTestClass2 instance) =>
       'firstName': instance.firstName,
       'lastName': instance.lastName,
       'height': instance.height,
-      'dateOfBirth': instance.dateOfBirth.toIso8601String(),
+      'dateOfBirth': instance.dateOfBirth.toUtc().toIso8601String(),
     };
 ''')
 @JsonSerializable()

--- a/json_serializable/test/supported_types/input.type_datetime.g.dart
+++ b/json_serializable/test/supported_types/input.type_datetime.g.dart
@@ -27,5 +27,5 @@ SimpleClassNullable _$SimpleClassNullableFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$SimpleClassNullableToJson(
         SimpleClassNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.toUtc()?.toIso8601String(),
+      'value': instance.value?.toUtc().toIso8601String(),
     };

--- a/json_serializable/test/supported_types/input.type_datetime.g.dart
+++ b/json_serializable/test/supported_types/input.type_datetime.g.dart
@@ -15,7 +15,7 @@ SimpleClass _$SimpleClassFromJson(Map<String, dynamic> json) {
 
 Map<String, dynamic> _$SimpleClassToJson(SimpleClass instance) =>
     <String, dynamic>{
-      'value': instance.value.toIso8601String(),
+      'value': instance.value.toUtc().toIso8601String(),
     };
 
 SimpleClassNullable _$SimpleClassNullableFromJson(Map<String, dynamic> json) {
@@ -27,5 +27,5 @@ SimpleClassNullable _$SimpleClassNullableFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$SimpleClassNullableToJson(
         SimpleClassNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.toIso8601String(),
+      'value': instance.value?.toUtc()?.toIso8601String(),
     };

--- a/json_serializable/test/supported_types/input.type_iterable.g.dart
+++ b/json_serializable/test/supported_types/input.type_iterable.g.dart
@@ -174,8 +174,7 @@ SimpleClassOfDateTimeNullable _$SimpleClassOfDateTimeNullableFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeNullableToJson(
         SimpleClassOfDateTimeNullable instance) =>
     <String, dynamic>{
-      'value':
-          instance.value.map((e) => e?.toUtc().toIso8601String()).toList(),
+      'value': instance.value.map((e) => e?.toUtc().toIso8601String()).toList(),
     };
 
 SimpleClassNullableOfDateTimeNullable

--- a/json_serializable/test/supported_types/input.type_iterable.g.dart
+++ b/json_serializable/test/supported_types/input.type_iterable.g.dart
@@ -147,7 +147,7 @@ SimpleClassOfDateTime _$SimpleClassOfDateTimeFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToJson(
         SimpleClassOfDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value.map((e) => e.toIso8601String()).toList(),
+      'value': instance.value.map((e) => e.toUtc().toIso8601String()).toList(),
     };
 
 SimpleClassNullableOfDateTime _$SimpleClassNullableOfDateTimeFromJson(
@@ -160,7 +160,7 @@ SimpleClassNullableOfDateTime _$SimpleClassNullableOfDateTimeFromJson(
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToJson(
         SimpleClassNullableOfDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((e) => e.toIso8601String()).toList(),
+      'value': instance.value?.map((e) => e.toUtc().toIso8601String()).toList(),
     };
 
 SimpleClassOfDateTimeNullable _$SimpleClassOfDateTimeNullableFromJson(
@@ -174,7 +174,7 @@ SimpleClassOfDateTimeNullable _$SimpleClassOfDateTimeNullableFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeNullableToJson(
         SimpleClassOfDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((e) => e?.toIso8601String()).toList(),
+      'value': instance.value.map((e) => e?.toUtc()?.toIso8601String()).toList(),
     };
 
 SimpleClassNullableOfDateTimeNullable
@@ -188,7 +188,7 @@ SimpleClassNullableOfDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeNullableToJson(
         SimpleClassNullableOfDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((e) => e?.toIso8601String()).toList(),
+      'value': instance.value?.map((e) => e?.toUtc()?.toIso8601String()).toList(),
     };
 
 SimpleClassOfDouble _$SimpleClassOfDoubleFromJson(Map<String, dynamic> json) {

--- a/json_serializable/test/supported_types/input.type_iterable.g.dart
+++ b/json_serializable/test/supported_types/input.type_iterable.g.dart
@@ -175,7 +175,7 @@ Map<String, dynamic> _$SimpleClassOfDateTimeNullableToJson(
         SimpleClassOfDateTimeNullable instance) =>
     <String, dynamic>{
       'value':
-          instance.value.map((e) => e?.toUtc()?.toIso8601String()).toList(),
+          instance.value.map((e) => e?.toUtc().toIso8601String()).toList(),
     };
 
 SimpleClassNullableOfDateTimeNullable
@@ -190,7 +190,7 @@ Map<String, dynamic> _$SimpleClassNullableOfDateTimeNullableToJson(
         SimpleClassNullableOfDateTimeNullable instance) =>
     <String, dynamic>{
       'value':
-          instance.value?.map((e) => e?.toUtc()?.toIso8601String()).toList(),
+          instance.value?.map((e) => e?.toUtc().toIso8601String()).toList(),
     };
 
 SimpleClassOfDouble _$SimpleClassOfDoubleFromJson(Map<String, dynamic> json) {

--- a/json_serializable/test/supported_types/input.type_iterable.g.dart
+++ b/json_serializable/test/supported_types/input.type_iterable.g.dart
@@ -174,7 +174,8 @@ SimpleClassOfDateTimeNullable _$SimpleClassOfDateTimeNullableFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeNullableToJson(
         SimpleClassOfDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((e) => e?.toUtc()?.toIso8601String()).toList(),
+      'value':
+          instance.value.map((e) => e?.toUtc()?.toIso8601String()).toList(),
     };
 
 SimpleClassNullableOfDateTimeNullable
@@ -188,7 +189,8 @@ SimpleClassNullableOfDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeNullableToJson(
         SimpleClassNullableOfDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((e) => e?.toUtc()?.toIso8601String()).toList(),
+      'value':
+          instance.value?.map((e) => e?.toUtc()?.toIso8601String()).toList(),
     };
 
 SimpleClassOfDouble _$SimpleClassOfDoubleFromJson(Map<String, dynamic> json) {

--- a/json_serializable/test/supported_types/input.type_list.g.dart
+++ b/json_serializable/test/supported_types/input.type_list.g.dart
@@ -185,7 +185,8 @@ SimpleClassOfDateTimeNullable _$SimpleClassOfDateTimeNullableFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeNullableToJson(
         SimpleClassOfDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((e) => e?.toUtc()?.toIso8601String()).toList(),
+      'value':
+          instance.value.map((e) => e?.toUtc()?.toIso8601String()).toList(),
     };
 
 SimpleClassNullableOfDateTimeNullable
@@ -200,7 +201,8 @@ SimpleClassNullableOfDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeNullableToJson(
         SimpleClassNullableOfDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((e) => e?.toUtc()?.toIso8601String()).toList(),
+      'value':
+          instance.value?.map((e) => e?.toUtc()?.toIso8601String()).toList(),
     };
 
 SimpleClassOfDouble _$SimpleClassOfDoubleFromJson(Map<String, dynamic> json) {

--- a/json_serializable/test/supported_types/input.type_list.g.dart
+++ b/json_serializable/test/supported_types/input.type_list.g.dart
@@ -186,7 +186,7 @@ Map<String, dynamic> _$SimpleClassOfDateTimeNullableToJson(
         SimpleClassOfDateTimeNullable instance) =>
     <String, dynamic>{
       'value':
-          instance.value.map((e) => e?.toUtc()?.toIso8601String()).toList(),
+          instance.value.map((e) => e?.toUtc().toIso8601String()).toList(),
     };
 
 SimpleClassNullableOfDateTimeNullable
@@ -202,7 +202,7 @@ Map<String, dynamic> _$SimpleClassNullableOfDateTimeNullableToJson(
         SimpleClassNullableOfDateTimeNullable instance) =>
     <String, dynamic>{
       'value':
-          instance.value?.map((e) => e?.toUtc()?.toIso8601String()).toList(),
+          instance.value?.map((e) => e?.toUtc().toIso8601String()).toList(),
     };
 
 SimpleClassOfDouble _$SimpleClassOfDoubleFromJson(Map<String, dynamic> json) {

--- a/json_serializable/test/supported_types/input.type_list.g.dart
+++ b/json_serializable/test/supported_types/input.type_list.g.dart
@@ -155,7 +155,7 @@ SimpleClassOfDateTime _$SimpleClassOfDateTimeFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToJson(
         SimpleClassOfDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value.map((e) => e.toIso8601String()).toList(),
+      'value': instance.value.map((e) => e.toUtc().toIso8601String()).toList(),
     };
 
 SimpleClassNullableOfDateTime _$SimpleClassNullableOfDateTimeFromJson(
@@ -170,7 +170,7 @@ SimpleClassNullableOfDateTime _$SimpleClassNullableOfDateTimeFromJson(
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToJson(
         SimpleClassNullableOfDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((e) => e.toIso8601String()).toList(),
+      'value': instance.value?.map((e) => e.toUtc().toIso8601String()).toList(),
     };
 
 SimpleClassOfDateTimeNullable _$SimpleClassOfDateTimeNullableFromJson(
@@ -185,7 +185,7 @@ SimpleClassOfDateTimeNullable _$SimpleClassOfDateTimeNullableFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeNullableToJson(
         SimpleClassOfDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((e) => e?.toIso8601String()).toList(),
+      'value': instance.value.map((e) => e?.toUtc()?.toIso8601String()).toList(),
     };
 
 SimpleClassNullableOfDateTimeNullable
@@ -200,7 +200,7 @@ SimpleClassNullableOfDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeNullableToJson(
         SimpleClassNullableOfDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((e) => e?.toIso8601String()).toList(),
+      'value': instance.value?.map((e) => e?.toUtc()?.toIso8601String()).toList(),
     };
 
 SimpleClassOfDouble _$SimpleClassOfDoubleFromJson(Map<String, dynamic> json) {

--- a/json_serializable/test/supported_types/input.type_list.g.dart
+++ b/json_serializable/test/supported_types/input.type_list.g.dart
@@ -185,8 +185,7 @@ SimpleClassOfDateTimeNullable _$SimpleClassOfDateTimeNullableFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeNullableToJson(
         SimpleClassOfDateTimeNullable instance) =>
     <String, dynamic>{
-      'value':
-          instance.value.map((e) => e?.toUtc().toIso8601String()).toList(),
+      'value': instance.value.map((e) => e?.toUtc().toIso8601String()).toList(),
     };
 
 SimpleClassNullableOfDateTimeNullable

--- a/json_serializable/test/supported_types/input.type_map.g.dart
+++ b/json_serializable/test/supported_types/input.type_map.g.dart
@@ -629,7 +629,8 @@ SimpleClassOfDateTimeToBool _$SimpleClassOfDateTimeToBoolFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToBoolToJson(
         SimpleClassOfDateTimeToBool instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToBool
@@ -644,7 +645,8 @@ SimpleClassNullableOfDateTimeToBool
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToBoolToJson(
         SimpleClassNullableOfDateTimeToBool instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToBool _$SimpleClassOfDynamicToBoolFromJson(
@@ -864,7 +866,8 @@ SimpleClassOfDateTimeToBoolNullable
 Map<String, dynamic> _$SimpleClassOfDateTimeToBoolNullableToJson(
         SimpleClassOfDateTimeToBoolNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToBoolNullable
@@ -880,7 +883,8 @@ SimpleClassNullableOfDateTimeToBoolNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToBoolNullableToJson(
         SimpleClassNullableOfDateTimeToBoolNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToBoolNullable _$SimpleClassOfDynamicToBoolNullableFromJson(
@@ -1107,8 +1111,8 @@ SimpleClassOfDateTimeToDateTime _$SimpleClassOfDateTimeToDateTimeFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToDateTimeToJson(
         SimpleClassOfDateTimeToDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value
-          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e.toUtc().toIso8601String())),
+      'value': instance.value.map((k, e) =>
+          MapEntry(k.toUtc().toIso8601String(), e.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfDateTimeToDateTime
@@ -1124,8 +1128,8 @@ SimpleClassNullableOfDateTimeToDateTime
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToDateTimeToJson(
         SimpleClassNullableOfDateTimeToDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value
-          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e.toUtc().toIso8601String())),
+      'value': instance.value?.map((k, e) =>
+          MapEntry(k.toUtc().toIso8601String(), e.toUtc().toIso8601String())),
     };
 
 SimpleClassOfDynamicToDateTime _$SimpleClassOfDynamicToDateTimeFromJson(
@@ -1140,7 +1144,8 @@ SimpleClassOfDynamicToDateTime _$SimpleClassOfDynamicToDateTimeFromJson(
 Map<String, dynamic> _$SimpleClassOfDynamicToDateTimeToJson(
         SimpleClassOfDynamicToDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
+      'value': instance.value
+          .map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfDynamicToDateTime
@@ -1156,7 +1161,8 @@ SimpleClassNullableOfDynamicToDateTime
 Map<String, dynamic> _$SimpleClassNullableOfDynamicToDateTimeToJson(
         SimpleClassNullableOfDynamicToDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
     };
 
 SimpleClassOfEnumTypeToDateTime _$SimpleClassOfEnumTypeToDateTimeFromJson(
@@ -1172,8 +1178,8 @@ SimpleClassOfEnumTypeToDateTime _$SimpleClassOfEnumTypeToDateTimeFromJson(
 Map<String, dynamic> _$SimpleClassOfEnumTypeToDateTimeToJson(
         SimpleClassOfEnumTypeToDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value
-          .map((k, e) => MapEntry(_$EnumTypeEnumMap[k], e.toUtc().toIso8601String())),
+      'value': instance.value.map((k, e) =>
+          MapEntry(_$EnumTypeEnumMap[k], e.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfEnumTypeToDateTime
@@ -1190,8 +1196,8 @@ SimpleClassNullableOfEnumTypeToDateTime
 Map<String, dynamic> _$SimpleClassNullableOfEnumTypeToDateTimeToJson(
         SimpleClassNullableOfEnumTypeToDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value
-          ?.map((k, e) => MapEntry(_$EnumTypeEnumMap[k], e.toUtc().toIso8601String())),
+      'value': instance.value?.map((k, e) =>
+          MapEntry(_$EnumTypeEnumMap[k], e.toUtc().toIso8601String())),
     };
 
 SimpleClassOfIntToDateTime _$SimpleClassOfIntToDateTimeFromJson(
@@ -1238,7 +1244,8 @@ SimpleClassOfObjectToDateTime _$SimpleClassOfObjectToDateTimeFromJson(
 Map<String, dynamic> _$SimpleClassOfObjectToDateTimeToJson(
         SimpleClassOfObjectToDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
+      'value': instance.value
+          .map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfObjectToDateTime
@@ -1253,7 +1260,8 @@ SimpleClassNullableOfObjectToDateTime
 Map<String, dynamic> _$SimpleClassNullableOfObjectToDateTimeToJson(
         SimpleClassNullableOfObjectToDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
     };
 
 SimpleClassOfStringToDateTime _$SimpleClassOfStringToDateTimeFromJson(
@@ -1268,7 +1276,8 @@ SimpleClassOfStringToDateTime _$SimpleClassOfStringToDateTimeFromJson(
 Map<String, dynamic> _$SimpleClassOfStringToDateTimeToJson(
         SimpleClassOfStringToDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
+      'value': instance.value
+          .map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfStringToDateTime
@@ -1283,7 +1292,8 @@ SimpleClassNullableOfStringToDateTime
 Map<String, dynamic> _$SimpleClassNullableOfStringToDateTimeToJson(
         SimpleClassNullableOfStringToDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
     };
 
 SimpleClassOfUriToDateTime _$SimpleClassOfUriToDateTimeFromJson(
@@ -1349,8 +1359,8 @@ SimpleClassNullableOfBigIntToDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfBigIntToDateTimeNullableToJson(
         SimpleClassNullableOfBigIntToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value
-          ?.map((k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
+      'value': instance.value?.map(
+          (k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassOfDateTimeToDateTimeNullable
@@ -1367,8 +1377,8 @@ SimpleClassOfDateTimeToDateTimeNullable
 Map<String, dynamic> _$SimpleClassOfDateTimeToDateTimeNullableToJson(
         SimpleClassOfDateTimeToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value
-          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e?.toUtc()?.toIso8601String())),
+      'value': instance.value.map((k, e) =>
+          MapEntry(k.toUtc().toIso8601String(), e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassNullableOfDateTimeToDateTimeNullable
@@ -1385,8 +1395,8 @@ SimpleClassNullableOfDateTimeToDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToDateTimeNullableToJson(
         SimpleClassNullableOfDateTimeToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value
-          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e?.toUtc()?.toIso8601String())),
+      'value': instance.value?.map((k, e) =>
+          MapEntry(k.toUtc().toIso8601String(), e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassOfDynamicToDateTimeNullable
@@ -1402,7 +1412,8 @@ SimpleClassOfDynamicToDateTimeNullable
 Map<String, dynamic> _$SimpleClassOfDynamicToDateTimeNullableToJson(
         SimpleClassOfDynamicToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
+      'value': instance.value
+          .map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassNullableOfDynamicToDateTimeNullable
@@ -1418,7 +1429,8 @@ SimpleClassNullableOfDynamicToDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfDynamicToDateTimeNullableToJson(
         SimpleClassNullableOfDynamicToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassOfEnumTypeToDateTimeNullable
@@ -1435,8 +1447,8 @@ SimpleClassOfEnumTypeToDateTimeNullable
 Map<String, dynamic> _$SimpleClassOfEnumTypeToDateTimeNullableToJson(
         SimpleClassOfEnumTypeToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value
-          .map((k, e) => MapEntry(_$EnumTypeEnumMap[k], e?.toUtc()?.toIso8601String())),
+      'value': instance.value.map((k, e) =>
+          MapEntry(_$EnumTypeEnumMap[k], e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassNullableOfEnumTypeToDateTimeNullable
@@ -1453,8 +1465,8 @@ SimpleClassNullableOfEnumTypeToDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfEnumTypeToDateTimeNullableToJson(
         SimpleClassNullableOfEnumTypeToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value
-          ?.map((k, e) => MapEntry(_$EnumTypeEnumMap[k], e?.toUtc()?.toIso8601String())),
+      'value': instance.value?.map((k, e) =>
+          MapEntry(_$EnumTypeEnumMap[k], e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassOfIntToDateTimeNullable _$SimpleClassOfIntToDateTimeNullableFromJson(
@@ -1488,8 +1500,8 @@ SimpleClassNullableOfIntToDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfIntToDateTimeNullableToJson(
         SimpleClassNullableOfIntToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value
-          ?.map((k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
+      'value': instance.value?.map(
+          (k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassOfObjectToDateTimeNullable
@@ -1504,7 +1516,8 @@ SimpleClassOfObjectToDateTimeNullable
 Map<String, dynamic> _$SimpleClassOfObjectToDateTimeNullableToJson(
         SimpleClassOfObjectToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
+      'value': instance.value
+          .map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassNullableOfObjectToDateTimeNullable
@@ -1520,7 +1533,8 @@ SimpleClassNullableOfObjectToDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfObjectToDateTimeNullableToJson(
         SimpleClassNullableOfObjectToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassOfStringToDateTimeNullable
@@ -1535,7 +1549,8 @@ SimpleClassOfStringToDateTimeNullable
 Map<String, dynamic> _$SimpleClassOfStringToDateTimeNullableToJson(
         SimpleClassOfStringToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
+      'value': instance.value
+          .map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassNullableOfStringToDateTimeNullable
@@ -1551,7 +1566,8 @@ SimpleClassNullableOfStringToDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfStringToDateTimeNullableToJson(
         SimpleClassNullableOfStringToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassOfUriToDateTimeNullable _$SimpleClassOfUriToDateTimeNullableFromJson(
@@ -1585,8 +1601,8 @@ SimpleClassNullableOfUriToDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfUriToDateTimeNullableToJson(
         SimpleClassNullableOfUriToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value
-          ?.map((k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
+      'value': instance.value?.map(
+          (k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassOfBigIntToDouble _$SimpleClassOfBigIntToDoubleFromJson(
@@ -1631,7 +1647,8 @@ SimpleClassOfDateTimeToDouble _$SimpleClassOfDateTimeToDoubleFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToDoubleToJson(
         SimpleClassOfDateTimeToDouble instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToDouble
@@ -1646,7 +1663,8 @@ SimpleClassNullableOfDateTimeToDouble
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToDoubleToJson(
         SimpleClassNullableOfDateTimeToDouble instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToDouble _$SimpleClassOfDynamicToDoubleFromJson(
@@ -1868,7 +1886,8 @@ SimpleClassOfDateTimeToDoubleNullable
 Map<String, dynamic> _$SimpleClassOfDateTimeToDoubleNullableToJson(
         SimpleClassOfDateTimeToDoubleNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToDoubleNullable
@@ -1884,7 +1903,8 @@ SimpleClassNullableOfDateTimeToDoubleNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToDoubleNullableToJson(
         SimpleClassNullableOfDateTimeToDoubleNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToDoubleNullable
@@ -2113,8 +2133,8 @@ SimpleClassOfDateTimeToDuration _$SimpleClassOfDateTimeToDurationFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToDurationToJson(
         SimpleClassOfDateTimeToDuration instance) =>
     <String, dynamic>{
-      'value': instance.value
-          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e.inMicroseconds)),
+      'value': instance.value.map(
+          (k, e) => MapEntry(k.toUtc().toIso8601String(), e.inMicroseconds)),
     };
 
 SimpleClassNullableOfDateTimeToDuration
@@ -2130,8 +2150,8 @@ SimpleClassNullableOfDateTimeToDuration
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToDurationToJson(
         SimpleClassNullableOfDateTimeToDuration instance) =>
     <String, dynamic>{
-      'value': instance.value
-          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e.inMicroseconds)),
+      'value': instance.value?.map(
+          (k, e) => MapEntry(k.toUtc().toIso8601String(), e.inMicroseconds)),
     };
 
 SimpleClassOfDynamicToDuration _$SimpleClassOfDynamicToDurationFromJson(
@@ -2373,8 +2393,8 @@ SimpleClassOfDateTimeToDurationNullable
 Map<String, dynamic> _$SimpleClassOfDateTimeToDurationNullableToJson(
         SimpleClassOfDateTimeToDurationNullable instance) =>
     <String, dynamic>{
-      'value': instance.value
-          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e?.inMicroseconds)),
+      'value': instance.value.map(
+          (k, e) => MapEntry(k.toUtc().toIso8601String(), e?.inMicroseconds)),
     };
 
 SimpleClassNullableOfDateTimeToDurationNullable
@@ -2391,8 +2411,8 @@ SimpleClassNullableOfDateTimeToDurationNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToDurationNullableToJson(
         SimpleClassNullableOfDateTimeToDurationNullable instance) =>
     <String, dynamic>{
-      'value': instance.value
-          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e?.inMicroseconds)),
+      'value': instance.value?.map(
+          (k, e) => MapEntry(k.toUtc().toIso8601String(), e?.inMicroseconds)),
     };
 
 SimpleClassOfDynamicToDurationNullable
@@ -2643,7 +2663,8 @@ SimpleClassOfDateTimeToDynamic _$SimpleClassOfDateTimeToDynamicFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToDynamicToJson(
         SimpleClassOfDateTimeToDynamic instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToDynamic
@@ -2659,7 +2680,8 @@ SimpleClassNullableOfDateTimeToDynamic
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToDynamicToJson(
         SimpleClassNullableOfDateTimeToDynamic instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToDynamic _$SimpleClassOfDynamicToDynamicFromJson(
@@ -2875,8 +2897,8 @@ SimpleClassOfDateTimeToEnumType _$SimpleClassOfDateTimeToEnumTypeFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToEnumTypeToJson(
         SimpleClassOfDateTimeToEnumType instance) =>
     <String, dynamic>{
-      'value': instance.value
-          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), _$EnumTypeEnumMap[e])),
+      'value': instance.value.map((k, e) =>
+          MapEntry(k.toUtc().toIso8601String(), _$EnumTypeEnumMap[e])),
     };
 
 SimpleClassNullableOfDateTimeToEnumType
@@ -2892,8 +2914,8 @@ SimpleClassNullableOfDateTimeToEnumType
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToEnumTypeToJson(
         SimpleClassNullableOfDateTimeToEnumType instance) =>
     <String, dynamic>{
-      'value': instance.value
-          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), _$EnumTypeEnumMap[e])),
+      'value': instance.value?.map((k, e) =>
+          MapEntry(k.toUtc().toIso8601String(), _$EnumTypeEnumMap[e])),
     };
 
 SimpleClassOfDynamicToEnumType _$SimpleClassOfDynamicToEnumTypeFromJson(
@@ -3146,8 +3168,8 @@ SimpleClassOfDateTimeToEnumTypeNullable
 Map<String, dynamic> _$SimpleClassOfDateTimeToEnumTypeNullableToJson(
         SimpleClassOfDateTimeToEnumTypeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value
-          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), _$EnumTypeEnumMap[e])),
+      'value': instance.value.map((k, e) =>
+          MapEntry(k.toUtc().toIso8601String(), _$EnumTypeEnumMap[e])),
     };
 
 SimpleClassNullableOfDateTimeToEnumTypeNullable
@@ -3164,8 +3186,8 @@ SimpleClassNullableOfDateTimeToEnumTypeNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToEnumTypeNullableToJson(
         SimpleClassNullableOfDateTimeToEnumTypeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value
-          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), _$EnumTypeEnumMap[e])),
+      'value': instance.value?.map((k, e) =>
+          MapEntry(k.toUtc().toIso8601String(), _$EnumTypeEnumMap[e])),
     };
 
 SimpleClassOfDynamicToEnumTypeNullable
@@ -3410,7 +3432,8 @@ SimpleClassOfDateTimeToInt _$SimpleClassOfDateTimeToIntFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToIntToJson(
         SimpleClassOfDateTimeToInt instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToInt _$SimpleClassNullableOfDateTimeToIntFromJson(
@@ -3425,7 +3448,8 @@ SimpleClassNullableOfDateTimeToInt _$SimpleClassNullableOfDateTimeToIntFromJson(
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToIntToJson(
         SimpleClassNullableOfDateTimeToInt instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToInt _$SimpleClassOfDynamicToIntFromJson(
@@ -3645,7 +3669,8 @@ SimpleClassOfDateTimeToIntNullable _$SimpleClassOfDateTimeToIntNullableFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToIntNullableToJson(
         SimpleClassOfDateTimeToIntNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToIntNullable
@@ -3661,7 +3686,8 @@ SimpleClassNullableOfDateTimeToIntNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToIntNullableToJson(
         SimpleClassNullableOfDateTimeToIntNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToIntNullable _$SimpleClassOfDynamicToIntNullableFromJson(
@@ -3884,7 +3910,8 @@ SimpleClassOfDateTimeToNum _$SimpleClassOfDateTimeToNumFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToNumToJson(
         SimpleClassOfDateTimeToNum instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToNum _$SimpleClassNullableOfDateTimeToNumFromJson(
@@ -3899,7 +3926,8 @@ SimpleClassNullableOfDateTimeToNum _$SimpleClassNullableOfDateTimeToNumFromJson(
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToNumToJson(
         SimpleClassNullableOfDateTimeToNum instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToNum _$SimpleClassOfDynamicToNumFromJson(
@@ -4119,7 +4147,8 @@ SimpleClassOfDateTimeToNumNullable _$SimpleClassOfDateTimeToNumNullableFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToNumNullableToJson(
         SimpleClassOfDateTimeToNumNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToNumNullable
@@ -4135,7 +4164,8 @@ SimpleClassNullableOfDateTimeToNumNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToNumNullableToJson(
         SimpleClassNullableOfDateTimeToNumNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToNumNullable _$SimpleClassOfDynamicToNumNullableFromJson(
@@ -4358,7 +4388,8 @@ SimpleClassOfDateTimeToObject _$SimpleClassOfDateTimeToObjectFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToObjectToJson(
         SimpleClassOfDateTimeToObject instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToObject
@@ -4373,7 +4404,8 @@ SimpleClassNullableOfDateTimeToObject
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToObjectToJson(
         SimpleClassNullableOfDateTimeToObject instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToObject _$SimpleClassOfDynamicToObjectFromJson(
@@ -4599,7 +4631,8 @@ SimpleClassOfDateTimeToObjectNullable
 Map<String, dynamic> _$SimpleClassOfDateTimeToObjectNullableToJson(
         SimpleClassOfDateTimeToObjectNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToObjectNullable
@@ -4615,7 +4648,8 @@ SimpleClassNullableOfDateTimeToObjectNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToObjectNullableToJson(
         SimpleClassNullableOfDateTimeToObjectNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToObjectNullable
@@ -4834,7 +4868,8 @@ SimpleClassOfDateTimeToString _$SimpleClassOfDateTimeToStringFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToStringToJson(
         SimpleClassOfDateTimeToString instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToString
@@ -4849,7 +4884,8 @@ SimpleClassNullableOfDateTimeToString
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToStringToJson(
         SimpleClassNullableOfDateTimeToString instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToString _$SimpleClassOfDynamicToStringFromJson(
@@ -5069,7 +5105,8 @@ SimpleClassOfDateTimeToStringNullable
 Map<String, dynamic> _$SimpleClassOfDateTimeToStringNullableToJson(
         SimpleClassOfDateTimeToStringNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToStringNullable
@@ -5085,7 +5122,8 @@ SimpleClassNullableOfDateTimeToStringNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToStringNullableToJson(
         SimpleClassNullableOfDateTimeToStringNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToStringNullable

--- a/json_serializable/test/supported_types/input.type_map.g.dart
+++ b/json_serializable/test/supported_types/input.type_map.g.dart
@@ -1342,7 +1342,7 @@ Map<String, dynamic> _$SimpleClassOfBigIntToDateTimeNullableToJson(
         SimpleClassOfBigIntToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
+          .map((k, e) => MapEntry(k.toString(), e?.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfBigIntToDateTimeNullable
@@ -1360,7 +1360,7 @@ Map<String, dynamic> _$SimpleClassNullableOfBigIntToDateTimeNullableToJson(
         SimpleClassNullableOfBigIntToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value?.map(
-          (k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
+          (k, e) => MapEntry(k.toString(), e?.toUtc().toIso8601String())),
     };
 
 SimpleClassOfDateTimeToDateTimeNullable
@@ -1378,7 +1378,7 @@ Map<String, dynamic> _$SimpleClassOfDateTimeToDateTimeNullableToJson(
         SimpleClassOfDateTimeToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value.map((k, e) =>
-          MapEntry(k.toUtc().toIso8601String(), e?.toUtc()?.toIso8601String())),
+          MapEntry(k.toUtc().toIso8601String(), e?.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfDateTimeToDateTimeNullable
@@ -1396,7 +1396,7 @@ Map<String, dynamic> _$SimpleClassNullableOfDateTimeToDateTimeNullableToJson(
         SimpleClassNullableOfDateTimeToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value?.map((k, e) =>
-          MapEntry(k.toUtc().toIso8601String(), e?.toUtc()?.toIso8601String())),
+          MapEntry(k.toUtc().toIso8601String(), e?.toUtc().toIso8601String())),
     };
 
 SimpleClassOfDynamicToDateTimeNullable
@@ -1413,7 +1413,7 @@ Map<String, dynamic> _$SimpleClassOfDynamicToDateTimeNullableToJson(
         SimpleClassOfDynamicToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
+          .map((k, e) => MapEntry(k, e?.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfDynamicToDateTimeNullable
@@ -1430,7 +1430,7 @@ Map<String, dynamic> _$SimpleClassNullableOfDynamicToDateTimeNullableToJson(
         SimpleClassNullableOfDynamicToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
+          ?.map((k, e) => MapEntry(k, e?.toUtc().toIso8601String())),
     };
 
 SimpleClassOfEnumTypeToDateTimeNullable
@@ -1448,7 +1448,7 @@ Map<String, dynamic> _$SimpleClassOfEnumTypeToDateTimeNullableToJson(
         SimpleClassOfEnumTypeToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value.map((k, e) =>
-          MapEntry(_$EnumTypeEnumMap[k], e?.toUtc()?.toIso8601String())),
+          MapEntry(_$EnumTypeEnumMap[k], e?.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfEnumTypeToDateTimeNullable
@@ -1466,7 +1466,7 @@ Map<String, dynamic> _$SimpleClassNullableOfEnumTypeToDateTimeNullableToJson(
         SimpleClassNullableOfEnumTypeToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value?.map((k, e) =>
-          MapEntry(_$EnumTypeEnumMap[k], e?.toUtc()?.toIso8601String())),
+          MapEntry(_$EnumTypeEnumMap[k], e?.toUtc().toIso8601String())),
     };
 
 SimpleClassOfIntToDateTimeNullable _$SimpleClassOfIntToDateTimeNullableFromJson(
@@ -1483,7 +1483,7 @@ Map<String, dynamic> _$SimpleClassOfIntToDateTimeNullableToJson(
         SimpleClassOfIntToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
+          .map((k, e) => MapEntry(k.toString(), e?.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfIntToDateTimeNullable
@@ -1501,7 +1501,7 @@ Map<String, dynamic> _$SimpleClassNullableOfIntToDateTimeNullableToJson(
         SimpleClassNullableOfIntToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value?.map(
-          (k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
+          (k, e) => MapEntry(k.toString(), e?.toUtc().toIso8601String())),
     };
 
 SimpleClassOfObjectToDateTimeNullable
@@ -1517,7 +1517,7 @@ Map<String, dynamic> _$SimpleClassOfObjectToDateTimeNullableToJson(
         SimpleClassOfObjectToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
+          .map((k, e) => MapEntry(k, e?.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfObjectToDateTimeNullable
@@ -1534,7 +1534,7 @@ Map<String, dynamic> _$SimpleClassNullableOfObjectToDateTimeNullableToJson(
         SimpleClassNullableOfObjectToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
+          ?.map((k, e) => MapEntry(k, e?.toUtc().toIso8601String())),
     };
 
 SimpleClassOfStringToDateTimeNullable
@@ -1550,7 +1550,7 @@ Map<String, dynamic> _$SimpleClassOfStringToDateTimeNullableToJson(
         SimpleClassOfStringToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
+          .map((k, e) => MapEntry(k, e?.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfStringToDateTimeNullable
@@ -1567,7 +1567,7 @@ Map<String, dynamic> _$SimpleClassNullableOfStringToDateTimeNullableToJson(
         SimpleClassNullableOfStringToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
+          ?.map((k, e) => MapEntry(k, e?.toUtc().toIso8601String())),
     };
 
 SimpleClassOfUriToDateTimeNullable _$SimpleClassOfUriToDateTimeNullableFromJson(
@@ -1584,7 +1584,7 @@ Map<String, dynamic> _$SimpleClassOfUriToDateTimeNullableToJson(
         SimpleClassOfUriToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
+          .map((k, e) => MapEntry(k.toString(), e?.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfUriToDateTimeNullable
@@ -1602,7 +1602,7 @@ Map<String, dynamic> _$SimpleClassNullableOfUriToDateTimeNullableToJson(
         SimpleClassNullableOfUriToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value?.map(
-          (k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
+          (k, e) => MapEntry(k.toString(), e?.toUtc().toIso8601String())),
     };
 
 SimpleClassOfBigIntToDouble _$SimpleClassOfBigIntToDoubleFromJson(

--- a/json_serializable/test/supported_types/input.type_map.g.dart
+++ b/json_serializable/test/supported_types/input.type_map.g.dart
@@ -1359,8 +1359,8 @@ SimpleClassNullableOfBigIntToDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfBigIntToDateTimeNullableToJson(
         SimpleClassNullableOfBigIntToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map(
-          (k, e) => MapEntry(k.toString(), e?.toUtc().toIso8601String())),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k.toString(), e?.toUtc().toIso8601String())),
     };
 
 SimpleClassOfDateTimeToDateTimeNullable
@@ -1500,8 +1500,8 @@ SimpleClassNullableOfIntToDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfIntToDateTimeNullableToJson(
         SimpleClassNullableOfIntToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map(
-          (k, e) => MapEntry(k.toString(), e?.toUtc().toIso8601String())),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k.toString(), e?.toUtc().toIso8601String())),
     };
 
 SimpleClassOfObjectToDateTimeNullable
@@ -1601,8 +1601,8 @@ SimpleClassNullableOfUriToDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfUriToDateTimeNullableToJson(
         SimpleClassNullableOfUriToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map(
-          (k, e) => MapEntry(k.toString(), e?.toUtc().toIso8601String())),
+      'value': instance.value
+          ?.map((k, e) => MapEntry(k.toString(), e?.toUtc().toIso8601String())),
     };
 
 SimpleClassOfBigIntToDouble _$SimpleClassOfBigIntToDoubleFromJson(

--- a/json_serializable/test/supported_types/input.type_map.g.dart
+++ b/json_serializable/test/supported_types/input.type_map.g.dart
@@ -79,7 +79,7 @@ Map<String, dynamic> _$SimpleClassOfDateTimeToBigIntToJson(
         SimpleClassOfDateTimeToBigInt instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toIso8601String(), e.toString())),
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e.toString())),
     };
 
 SimpleClassNullableOfDateTimeToBigInt
@@ -95,7 +95,7 @@ Map<String, dynamic> _$SimpleClassNullableOfDateTimeToBigIntToJson(
         SimpleClassNullableOfDateTimeToBigInt instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k.toIso8601String(), e.toString())),
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e.toString())),
     };
 
 SimpleClassOfDynamicToBigInt _$SimpleClassOfDynamicToBigIntFromJson(
@@ -368,7 +368,7 @@ Map<String, dynamic> _$SimpleClassOfDateTimeToBigIntNullableToJson(
         SimpleClassOfDateTimeToBigIntNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toIso8601String(), e?.toString())),
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e?.toString())),
     };
 
 SimpleClassNullableOfDateTimeToBigIntNullable
@@ -386,7 +386,7 @@ Map<String, dynamic> _$SimpleClassNullableOfDateTimeToBigIntNullableToJson(
         SimpleClassNullableOfDateTimeToBigIntNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k.toIso8601String(), e?.toString())),
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e?.toString())),
     };
 
 SimpleClassOfDynamicToBigIntNullable
@@ -629,7 +629,7 @@ SimpleClassOfDateTimeToBool _$SimpleClassOfDateTimeToBoolFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToBoolToJson(
         SimpleClassOfDateTimeToBool instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToBool
@@ -644,7 +644,7 @@ SimpleClassNullableOfDateTimeToBool
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToBoolToJson(
         SimpleClassNullableOfDateTimeToBool instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToBool _$SimpleClassOfDynamicToBoolFromJson(
@@ -864,7 +864,7 @@ SimpleClassOfDateTimeToBoolNullable
 Map<String, dynamic> _$SimpleClassOfDateTimeToBoolNullableToJson(
         SimpleClassOfDateTimeToBoolNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToBoolNullable
@@ -880,7 +880,7 @@ SimpleClassNullableOfDateTimeToBoolNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToBoolNullableToJson(
         SimpleClassNullableOfDateTimeToBoolNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToBoolNullable _$SimpleClassOfDynamicToBoolNullableFromJson(
@@ -1076,7 +1076,7 @@ Map<String, dynamic> _$SimpleClassOfBigIntToDateTimeToJson(
         SimpleClassOfBigIntToDateTime instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toString(), e.toIso8601String())),
+          .map((k, e) => MapEntry(k.toString(), e.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfBigIntToDateTime
@@ -1092,7 +1092,7 @@ Map<String, dynamic> _$SimpleClassNullableOfBigIntToDateTimeToJson(
         SimpleClassNullableOfBigIntToDateTime instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k.toString(), e.toIso8601String())),
+          ?.map((k, e) => MapEntry(k.toString(), e.toUtc().toIso8601String())),
     };
 
 SimpleClassOfDateTimeToDateTime _$SimpleClassOfDateTimeToDateTimeFromJson(
@@ -1108,7 +1108,7 @@ Map<String, dynamic> _$SimpleClassOfDateTimeToDateTimeToJson(
         SimpleClassOfDateTimeToDateTime instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toIso8601String(), e.toIso8601String())),
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfDateTimeToDateTime
@@ -1125,7 +1125,7 @@ Map<String, dynamic> _$SimpleClassNullableOfDateTimeToDateTimeToJson(
         SimpleClassNullableOfDateTimeToDateTime instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k.toIso8601String(), e.toIso8601String())),
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e.toUtc().toIso8601String())),
     };
 
 SimpleClassOfDynamicToDateTime _$SimpleClassOfDynamicToDateTimeFromJson(
@@ -1140,7 +1140,7 @@ SimpleClassOfDynamicToDateTime _$SimpleClassOfDynamicToDateTimeFromJson(
 Map<String, dynamic> _$SimpleClassOfDynamicToDateTimeToJson(
         SimpleClassOfDynamicToDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k, e.toIso8601String())),
+      'value': instance.value.map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfDynamicToDateTime
@@ -1156,7 +1156,7 @@ SimpleClassNullableOfDynamicToDateTime
 Map<String, dynamic> _$SimpleClassNullableOfDynamicToDateTimeToJson(
         SimpleClassNullableOfDynamicToDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k, e.toIso8601String())),
+      'value': instance.value?.map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
     };
 
 SimpleClassOfEnumTypeToDateTime _$SimpleClassOfEnumTypeToDateTimeFromJson(
@@ -1173,7 +1173,7 @@ Map<String, dynamic> _$SimpleClassOfEnumTypeToDateTimeToJson(
         SimpleClassOfEnumTypeToDateTime instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(_$EnumTypeEnumMap[k], e.toIso8601String())),
+          .map((k, e) => MapEntry(_$EnumTypeEnumMap[k], e.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfEnumTypeToDateTime
@@ -1191,7 +1191,7 @@ Map<String, dynamic> _$SimpleClassNullableOfEnumTypeToDateTimeToJson(
         SimpleClassNullableOfEnumTypeToDateTime instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(_$EnumTypeEnumMap[k], e.toIso8601String())),
+          ?.map((k, e) => MapEntry(_$EnumTypeEnumMap[k], e.toUtc().toIso8601String())),
     };
 
 SimpleClassOfIntToDateTime _$SimpleClassOfIntToDateTimeFromJson(
@@ -1207,7 +1207,7 @@ Map<String, dynamic> _$SimpleClassOfIntToDateTimeToJson(
         SimpleClassOfIntToDateTime instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toString(), e.toIso8601String())),
+          .map((k, e) => MapEntry(k.toString(), e.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfIntToDateTime _$SimpleClassNullableOfIntToDateTimeFromJson(
@@ -1223,7 +1223,7 @@ Map<String, dynamic> _$SimpleClassNullableOfIntToDateTimeToJson(
         SimpleClassNullableOfIntToDateTime instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k.toString(), e.toIso8601String())),
+          ?.map((k, e) => MapEntry(k.toString(), e.toUtc().toIso8601String())),
     };
 
 SimpleClassOfObjectToDateTime _$SimpleClassOfObjectToDateTimeFromJson(
@@ -1238,7 +1238,7 @@ SimpleClassOfObjectToDateTime _$SimpleClassOfObjectToDateTimeFromJson(
 Map<String, dynamic> _$SimpleClassOfObjectToDateTimeToJson(
         SimpleClassOfObjectToDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k, e.toIso8601String())),
+      'value': instance.value.map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfObjectToDateTime
@@ -1253,7 +1253,7 @@ SimpleClassNullableOfObjectToDateTime
 Map<String, dynamic> _$SimpleClassNullableOfObjectToDateTimeToJson(
         SimpleClassNullableOfObjectToDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k, e.toIso8601String())),
+      'value': instance.value?.map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
     };
 
 SimpleClassOfStringToDateTime _$SimpleClassOfStringToDateTimeFromJson(
@@ -1268,7 +1268,7 @@ SimpleClassOfStringToDateTime _$SimpleClassOfStringToDateTimeFromJson(
 Map<String, dynamic> _$SimpleClassOfStringToDateTimeToJson(
         SimpleClassOfStringToDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k, e.toIso8601String())),
+      'value': instance.value.map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfStringToDateTime
@@ -1283,7 +1283,7 @@ SimpleClassNullableOfStringToDateTime
 Map<String, dynamic> _$SimpleClassNullableOfStringToDateTimeToJson(
         SimpleClassNullableOfStringToDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k, e.toIso8601String())),
+      'value': instance.value?.map((k, e) => MapEntry(k, e.toUtc().toIso8601String())),
     };
 
 SimpleClassOfUriToDateTime _$SimpleClassOfUriToDateTimeFromJson(
@@ -1299,7 +1299,7 @@ Map<String, dynamic> _$SimpleClassOfUriToDateTimeToJson(
         SimpleClassOfUriToDateTime instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toString(), e.toIso8601String())),
+          .map((k, e) => MapEntry(k.toString(), e.toUtc().toIso8601String())),
     };
 
 SimpleClassNullableOfUriToDateTime _$SimpleClassNullableOfUriToDateTimeFromJson(
@@ -1315,7 +1315,7 @@ Map<String, dynamic> _$SimpleClassNullableOfUriToDateTimeToJson(
         SimpleClassNullableOfUriToDateTime instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k.toString(), e.toIso8601String())),
+          ?.map((k, e) => MapEntry(k.toString(), e.toUtc().toIso8601String())),
     };
 
 SimpleClassOfBigIntToDateTimeNullable
@@ -1332,7 +1332,7 @@ Map<String, dynamic> _$SimpleClassOfBigIntToDateTimeNullableToJson(
         SimpleClassOfBigIntToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toString(), e?.toIso8601String())),
+          .map((k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassNullableOfBigIntToDateTimeNullable
@@ -1350,7 +1350,7 @@ Map<String, dynamic> _$SimpleClassNullableOfBigIntToDateTimeNullableToJson(
         SimpleClassNullableOfBigIntToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k.toString(), e?.toIso8601String())),
+          ?.map((k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassOfDateTimeToDateTimeNullable
@@ -1368,7 +1368,7 @@ Map<String, dynamic> _$SimpleClassOfDateTimeToDateTimeNullableToJson(
         SimpleClassOfDateTimeToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toIso8601String(), e?.toIso8601String())),
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassNullableOfDateTimeToDateTimeNullable
@@ -1386,7 +1386,7 @@ Map<String, dynamic> _$SimpleClassNullableOfDateTimeToDateTimeNullableToJson(
         SimpleClassNullableOfDateTimeToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k.toIso8601String(), e?.toIso8601String())),
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassOfDynamicToDateTimeNullable
@@ -1402,7 +1402,7 @@ SimpleClassOfDynamicToDateTimeNullable
 Map<String, dynamic> _$SimpleClassOfDynamicToDateTimeNullableToJson(
         SimpleClassOfDynamicToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k, e?.toIso8601String())),
+      'value': instance.value.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassNullableOfDynamicToDateTimeNullable
@@ -1418,7 +1418,7 @@ SimpleClassNullableOfDynamicToDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfDynamicToDateTimeNullableToJson(
         SimpleClassNullableOfDynamicToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k, e?.toIso8601String())),
+      'value': instance.value?.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassOfEnumTypeToDateTimeNullable
@@ -1436,7 +1436,7 @@ Map<String, dynamic> _$SimpleClassOfEnumTypeToDateTimeNullableToJson(
         SimpleClassOfEnumTypeToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(_$EnumTypeEnumMap[k], e?.toIso8601String())),
+          .map((k, e) => MapEntry(_$EnumTypeEnumMap[k], e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassNullableOfEnumTypeToDateTimeNullable
@@ -1454,7 +1454,7 @@ Map<String, dynamic> _$SimpleClassNullableOfEnumTypeToDateTimeNullableToJson(
         SimpleClassNullableOfEnumTypeToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(_$EnumTypeEnumMap[k], e?.toIso8601String())),
+          ?.map((k, e) => MapEntry(_$EnumTypeEnumMap[k], e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassOfIntToDateTimeNullable _$SimpleClassOfIntToDateTimeNullableFromJson(
@@ -1471,7 +1471,7 @@ Map<String, dynamic> _$SimpleClassOfIntToDateTimeNullableToJson(
         SimpleClassOfIntToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toString(), e?.toIso8601String())),
+          .map((k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassNullableOfIntToDateTimeNullable
@@ -1489,7 +1489,7 @@ Map<String, dynamic> _$SimpleClassNullableOfIntToDateTimeNullableToJson(
         SimpleClassNullableOfIntToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k.toString(), e?.toIso8601String())),
+          ?.map((k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassOfObjectToDateTimeNullable
@@ -1504,7 +1504,7 @@ SimpleClassOfObjectToDateTimeNullable
 Map<String, dynamic> _$SimpleClassOfObjectToDateTimeNullableToJson(
         SimpleClassOfObjectToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k, e?.toIso8601String())),
+      'value': instance.value.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassNullableOfObjectToDateTimeNullable
@@ -1520,7 +1520,7 @@ SimpleClassNullableOfObjectToDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfObjectToDateTimeNullableToJson(
         SimpleClassNullableOfObjectToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k, e?.toIso8601String())),
+      'value': instance.value?.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassOfStringToDateTimeNullable
@@ -1535,7 +1535,7 @@ SimpleClassOfStringToDateTimeNullable
 Map<String, dynamic> _$SimpleClassOfStringToDateTimeNullableToJson(
         SimpleClassOfStringToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k, e?.toIso8601String())),
+      'value': instance.value.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassNullableOfStringToDateTimeNullable
@@ -1551,7 +1551,7 @@ SimpleClassNullableOfStringToDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfStringToDateTimeNullableToJson(
         SimpleClassNullableOfStringToDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k, e?.toIso8601String())),
+      'value': instance.value?.map((k, e) => MapEntry(k, e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassOfUriToDateTimeNullable _$SimpleClassOfUriToDateTimeNullableFromJson(
@@ -1568,7 +1568,7 @@ Map<String, dynamic> _$SimpleClassOfUriToDateTimeNullableToJson(
         SimpleClassOfUriToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toString(), e?.toIso8601String())),
+          .map((k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassNullableOfUriToDateTimeNullable
@@ -1586,7 +1586,7 @@ Map<String, dynamic> _$SimpleClassNullableOfUriToDateTimeNullableToJson(
         SimpleClassNullableOfUriToDateTimeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k.toString(), e?.toIso8601String())),
+          ?.map((k, e) => MapEntry(k.toString(), e?.toUtc()?.toIso8601String())),
     };
 
 SimpleClassOfBigIntToDouble _$SimpleClassOfBigIntToDoubleFromJson(
@@ -1631,7 +1631,7 @@ SimpleClassOfDateTimeToDouble _$SimpleClassOfDateTimeToDoubleFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToDoubleToJson(
         SimpleClassOfDateTimeToDouble instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToDouble
@@ -1646,7 +1646,7 @@ SimpleClassNullableOfDateTimeToDouble
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToDoubleToJson(
         SimpleClassNullableOfDateTimeToDouble instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToDouble _$SimpleClassOfDynamicToDoubleFromJson(
@@ -1868,7 +1868,7 @@ SimpleClassOfDateTimeToDoubleNullable
 Map<String, dynamic> _$SimpleClassOfDateTimeToDoubleNullableToJson(
         SimpleClassOfDateTimeToDoubleNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToDoubleNullable
@@ -1884,7 +1884,7 @@ SimpleClassNullableOfDateTimeToDoubleNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToDoubleNullableToJson(
         SimpleClassNullableOfDateTimeToDoubleNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToDoubleNullable
@@ -2114,7 +2114,7 @@ Map<String, dynamic> _$SimpleClassOfDateTimeToDurationToJson(
         SimpleClassOfDateTimeToDuration instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toIso8601String(), e.inMicroseconds)),
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e.inMicroseconds)),
     };
 
 SimpleClassNullableOfDateTimeToDuration
@@ -2131,7 +2131,7 @@ Map<String, dynamic> _$SimpleClassNullableOfDateTimeToDurationToJson(
         SimpleClassNullableOfDateTimeToDuration instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k.toIso8601String(), e.inMicroseconds)),
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e.inMicroseconds)),
     };
 
 SimpleClassOfDynamicToDuration _$SimpleClassOfDynamicToDurationFromJson(
@@ -2374,7 +2374,7 @@ Map<String, dynamic> _$SimpleClassOfDateTimeToDurationNullableToJson(
         SimpleClassOfDateTimeToDurationNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toIso8601String(), e?.inMicroseconds)),
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e?.inMicroseconds)),
     };
 
 SimpleClassNullableOfDateTimeToDurationNullable
@@ -2392,7 +2392,7 @@ Map<String, dynamic> _$SimpleClassNullableOfDateTimeToDurationNullableToJson(
         SimpleClassNullableOfDateTimeToDurationNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k.toIso8601String(), e?.inMicroseconds)),
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e?.inMicroseconds)),
     };
 
 SimpleClassOfDynamicToDurationNullable
@@ -2643,7 +2643,7 @@ SimpleClassOfDateTimeToDynamic _$SimpleClassOfDateTimeToDynamicFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToDynamicToJson(
         SimpleClassOfDateTimeToDynamic instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToDynamic
@@ -2659,7 +2659,7 @@ SimpleClassNullableOfDateTimeToDynamic
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToDynamicToJson(
         SimpleClassNullableOfDateTimeToDynamic instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToDynamic _$SimpleClassOfDynamicToDynamicFromJson(
@@ -2876,7 +2876,7 @@ Map<String, dynamic> _$SimpleClassOfDateTimeToEnumTypeToJson(
         SimpleClassOfDateTimeToEnumType instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toIso8601String(), _$EnumTypeEnumMap[e])),
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), _$EnumTypeEnumMap[e])),
     };
 
 SimpleClassNullableOfDateTimeToEnumType
@@ -2893,7 +2893,7 @@ Map<String, dynamic> _$SimpleClassNullableOfDateTimeToEnumTypeToJson(
         SimpleClassNullableOfDateTimeToEnumType instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k.toIso8601String(), _$EnumTypeEnumMap[e])),
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), _$EnumTypeEnumMap[e])),
     };
 
 SimpleClassOfDynamicToEnumType _$SimpleClassOfDynamicToEnumTypeFromJson(
@@ -3147,7 +3147,7 @@ Map<String, dynamic> _$SimpleClassOfDateTimeToEnumTypeNullableToJson(
         SimpleClassOfDateTimeToEnumTypeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toIso8601String(), _$EnumTypeEnumMap[e])),
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), _$EnumTypeEnumMap[e])),
     };
 
 SimpleClassNullableOfDateTimeToEnumTypeNullable
@@ -3165,7 +3165,7 @@ Map<String, dynamic> _$SimpleClassNullableOfDateTimeToEnumTypeNullableToJson(
         SimpleClassNullableOfDateTimeToEnumTypeNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k.toIso8601String(), _$EnumTypeEnumMap[e])),
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), _$EnumTypeEnumMap[e])),
     };
 
 SimpleClassOfDynamicToEnumTypeNullable
@@ -3410,7 +3410,7 @@ SimpleClassOfDateTimeToInt _$SimpleClassOfDateTimeToIntFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToIntToJson(
         SimpleClassOfDateTimeToInt instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToInt _$SimpleClassNullableOfDateTimeToIntFromJson(
@@ -3425,7 +3425,7 @@ SimpleClassNullableOfDateTimeToInt _$SimpleClassNullableOfDateTimeToIntFromJson(
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToIntToJson(
         SimpleClassNullableOfDateTimeToInt instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToInt _$SimpleClassOfDynamicToIntFromJson(
@@ -3645,7 +3645,7 @@ SimpleClassOfDateTimeToIntNullable _$SimpleClassOfDateTimeToIntNullableFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToIntNullableToJson(
         SimpleClassOfDateTimeToIntNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToIntNullable
@@ -3661,7 +3661,7 @@ SimpleClassNullableOfDateTimeToIntNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToIntNullableToJson(
         SimpleClassNullableOfDateTimeToIntNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToIntNullable _$SimpleClassOfDynamicToIntNullableFromJson(
@@ -3884,7 +3884,7 @@ SimpleClassOfDateTimeToNum _$SimpleClassOfDateTimeToNumFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToNumToJson(
         SimpleClassOfDateTimeToNum instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToNum _$SimpleClassNullableOfDateTimeToNumFromJson(
@@ -3899,7 +3899,7 @@ SimpleClassNullableOfDateTimeToNum _$SimpleClassNullableOfDateTimeToNumFromJson(
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToNumToJson(
         SimpleClassNullableOfDateTimeToNum instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToNum _$SimpleClassOfDynamicToNumFromJson(
@@ -4119,7 +4119,7 @@ SimpleClassOfDateTimeToNumNullable _$SimpleClassOfDateTimeToNumNullableFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToNumNullableToJson(
         SimpleClassOfDateTimeToNumNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToNumNullable
@@ -4135,7 +4135,7 @@ SimpleClassNullableOfDateTimeToNumNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToNumNullableToJson(
         SimpleClassNullableOfDateTimeToNumNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToNumNullable _$SimpleClassOfDynamicToNumNullableFromJson(
@@ -4358,7 +4358,7 @@ SimpleClassOfDateTimeToObject _$SimpleClassOfDateTimeToObjectFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToObjectToJson(
         SimpleClassOfDateTimeToObject instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToObject
@@ -4373,7 +4373,7 @@ SimpleClassNullableOfDateTimeToObject
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToObjectToJson(
         SimpleClassNullableOfDateTimeToObject instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToObject _$SimpleClassOfDynamicToObjectFromJson(
@@ -4599,7 +4599,7 @@ SimpleClassOfDateTimeToObjectNullable
 Map<String, dynamic> _$SimpleClassOfDateTimeToObjectNullableToJson(
         SimpleClassOfDateTimeToObjectNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToObjectNullable
@@ -4615,7 +4615,7 @@ SimpleClassNullableOfDateTimeToObjectNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToObjectNullableToJson(
         SimpleClassNullableOfDateTimeToObjectNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToObjectNullable
@@ -4834,7 +4834,7 @@ SimpleClassOfDateTimeToString _$SimpleClassOfDateTimeToStringFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToStringToJson(
         SimpleClassOfDateTimeToString instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToString
@@ -4849,7 +4849,7 @@ SimpleClassNullableOfDateTimeToString
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToStringToJson(
         SimpleClassNullableOfDateTimeToString instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToString _$SimpleClassOfDynamicToStringFromJson(
@@ -5069,7 +5069,7 @@ SimpleClassOfDateTimeToStringNullable
 Map<String, dynamic> _$SimpleClassOfDateTimeToStringNullableToJson(
         SimpleClassOfDateTimeToStringNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassNullableOfDateTimeToStringNullable
@@ -5085,7 +5085,7 @@ SimpleClassNullableOfDateTimeToStringNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToStringNullableToJson(
         SimpleClassNullableOfDateTimeToStringNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((k, e) => MapEntry(k.toIso8601String(), e)),
+      'value': instance.value?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e)),
     };
 
 SimpleClassOfDynamicToStringNullable
@@ -5313,7 +5313,7 @@ Map<String, dynamic> _$SimpleClassOfDateTimeToUriToJson(
         SimpleClassOfDateTimeToUri instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toIso8601String(), e.toString())),
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e.toString())),
     };
 
 SimpleClassNullableOfDateTimeToUri _$SimpleClassNullableOfDateTimeToUriFromJson(
@@ -5329,7 +5329,7 @@ Map<String, dynamic> _$SimpleClassNullableOfDateTimeToUriToJson(
         SimpleClassNullableOfDateTimeToUri instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k.toIso8601String(), e.toString())),
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e.toString())),
     };
 
 SimpleClassOfDynamicToUri _$SimpleClassOfDynamicToUriFromJson(
@@ -5569,7 +5569,7 @@ Map<String, dynamic> _$SimpleClassOfDateTimeToUriNullableToJson(
         SimpleClassOfDateTimeToUriNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          .map((k, e) => MapEntry(k.toIso8601String(), e?.toString())),
+          .map((k, e) => MapEntry(k.toUtc().toIso8601String(), e?.toString())),
     };
 
 SimpleClassNullableOfDateTimeToUriNullable
@@ -5587,7 +5587,7 @@ Map<String, dynamic> _$SimpleClassNullableOfDateTimeToUriNullableToJson(
         SimpleClassNullableOfDateTimeToUriNullable instance) =>
     <String, dynamic>{
       'value': instance.value
-          ?.map((k, e) => MapEntry(k.toIso8601String(), e?.toString())),
+          ?.map((k, e) => MapEntry(k.toUtc().toIso8601String(), e?.toString())),
     };
 
 SimpleClassOfDynamicToUriNullable _$SimpleClassOfDynamicToUriNullableFromJson(

--- a/json_serializable/test/supported_types/input.type_set.g.dart
+++ b/json_serializable/test/supported_types/input.type_set.g.dart
@@ -185,7 +185,8 @@ SimpleClassOfDateTimeNullable _$SimpleClassOfDateTimeNullableFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeNullableToJson(
         SimpleClassOfDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((e) => e?.toUtc()?.toIso8601String()).toList(),
+      'value':
+          instance.value.map((e) => e?.toUtc()?.toIso8601String()).toList(),
     };
 
 SimpleClassNullableOfDateTimeNullable
@@ -200,7 +201,8 @@ SimpleClassNullableOfDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeNullableToJson(
         SimpleClassNullableOfDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((e) => e?.toUtc()?.toIso8601String()).toList(),
+      'value':
+          instance.value?.map((e) => e?.toUtc()?.toIso8601String()).toList(),
     };
 
 SimpleClassOfDouble _$SimpleClassOfDoubleFromJson(Map<String, dynamic> json) {

--- a/json_serializable/test/supported_types/input.type_set.g.dart
+++ b/json_serializable/test/supported_types/input.type_set.g.dart
@@ -186,7 +186,7 @@ Map<String, dynamic> _$SimpleClassOfDateTimeNullableToJson(
         SimpleClassOfDateTimeNullable instance) =>
     <String, dynamic>{
       'value':
-          instance.value.map((e) => e?.toUtc()?.toIso8601String()).toList(),
+          instance.value.map((e) => e?.toUtc().toIso8601String()).toList(),
     };
 
 SimpleClassNullableOfDateTimeNullable
@@ -202,7 +202,7 @@ Map<String, dynamic> _$SimpleClassNullableOfDateTimeNullableToJson(
         SimpleClassNullableOfDateTimeNullable instance) =>
     <String, dynamic>{
       'value':
-          instance.value?.map((e) => e?.toUtc()?.toIso8601String()).toList(),
+          instance.value?.map((e) => e?.toUtc().toIso8601String()).toList(),
     };
 
 SimpleClassOfDouble _$SimpleClassOfDoubleFromJson(Map<String, dynamic> json) {

--- a/json_serializable/test/supported_types/input.type_set.g.dart
+++ b/json_serializable/test/supported_types/input.type_set.g.dart
@@ -155,7 +155,7 @@ SimpleClassOfDateTime _$SimpleClassOfDateTimeFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeToJson(
         SimpleClassOfDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value.map((e) => e.toIso8601String()).toList(),
+      'value': instance.value.map((e) => e.toUtc().toIso8601String()).toList(),
     };
 
 SimpleClassNullableOfDateTime _$SimpleClassNullableOfDateTimeFromJson(
@@ -170,7 +170,7 @@ SimpleClassNullableOfDateTime _$SimpleClassNullableOfDateTimeFromJson(
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeToJson(
         SimpleClassNullableOfDateTime instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((e) => e.toIso8601String()).toList(),
+      'value': instance.value?.map((e) => e.toUtc().toIso8601String()).toList(),
     };
 
 SimpleClassOfDateTimeNullable _$SimpleClassOfDateTimeNullableFromJson(
@@ -185,7 +185,7 @@ SimpleClassOfDateTimeNullable _$SimpleClassOfDateTimeNullableFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeNullableToJson(
         SimpleClassOfDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value.map((e) => e?.toIso8601String()).toList(),
+      'value': instance.value.map((e) => e?.toUtc()?.toIso8601String()).toList(),
     };
 
 SimpleClassNullableOfDateTimeNullable
@@ -200,7 +200,7 @@ SimpleClassNullableOfDateTimeNullable
 Map<String, dynamic> _$SimpleClassNullableOfDateTimeNullableToJson(
         SimpleClassNullableOfDateTimeNullable instance) =>
     <String, dynamic>{
-      'value': instance.value?.map((e) => e?.toIso8601String()).toList(),
+      'value': instance.value?.map((e) => e?.toUtc()?.toIso8601String()).toList(),
     };
 
 SimpleClassOfDouble _$SimpleClassOfDoubleFromJson(Map<String, dynamic> json) {

--- a/json_serializable/test/supported_types/input.type_set.g.dart
+++ b/json_serializable/test/supported_types/input.type_set.g.dart
@@ -185,8 +185,7 @@ SimpleClassOfDateTimeNullable _$SimpleClassOfDateTimeNullableFromJson(
 Map<String, dynamic> _$SimpleClassOfDateTimeNullableToJson(
         SimpleClassOfDateTimeNullable instance) =>
     <String, dynamic>{
-      'value':
-          instance.value.map((e) => e?.toUtc().toIso8601String()).toList(),
+      'value': instance.value.map((e) => e?.toUtc().toIso8601String()).toList(),
     };
 
 SimpleClassNullableOfDateTimeNullable


### PR DESCRIPTION
If a `DateTime` object is serialised for an HTTP request but it's not in UTC then the ISO8601 string will be invalid, as it won't contain the timezone (missing from the dart implementation of `DateTime`). This causes requests to either fail or use the server timezone, which may not be the same as that of the device.

I know that I better solution would be to fix the `DateTime` function `toIso8601String`, but this is an easy solution here.