### PR TITLE
Publish checked_yaml v2 null-safe, stable

### DIFF
--- a/checked_yaml/CHANGELOG.md
+++ b/checked_yaml/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0-dev
+## 2.0.0
 
 - *BREAKING* `checkedYamlDecode` `sourceUrl` parameter is now a `Uri`.
 - Require at least Dart `2.12.0-0`.

--- a/checked_yaml/pubspec.yaml
+++ b/checked_yaml/pubspec.yaml
@@ -1,28 +1,27 @@
 name: checked_yaml
-version: 1.9.0-dev
+version: 2.0.0
 
 description: >-
   Generate more helpful exceptions when decoding YAML documents using
   package:json_serializable and package:yaml.
-repository: https://github.com/google/json_serializable.dart
+repository: https://github.com/google/json_serializable.dart/tree/master/checked_yaml
 environment:
   sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
-  json_annotation: '>=2.2.0 <5.0.0'
+  json_annotation: ^4.0.0
   source_span: ^1.8.0
   yaml: ^3.0.0
 
 dev_dependencies:
   build_runner: ^1.0.0
   build_verify: ^1.1.0
-  json_serializable: ^3.0.0
+  json_serializable: ^4.0.0
   path: ^1.0.0
   test: ^1.16.0
   test_process: ^1.0.1
 
 dependency_overrides:
-  json_annotation:
-    path: ../json_annotation
-  json_serializable:
-    path: ../json_serializable
+  # Need to update dependencies on these packages
+  build_config: ^0.4.4
+  pubspec_parse: ^0.1.5


### PR DESCRIPTION
Fixes https://github.com/google/json_serializable.dart/issues/793
