### PR TITLE
Correctly handle nullable `Map` and `Iterable` JSON types...

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.2
+
+- Correctly handle nullable `Map` and `Iterable` JSON types exposed by both
+  class- and function-based converters.
+
 ## 4.0.1
 
 - Allow latest `package:analyzer`.

--- a/json_serializable/lib/src/shared_checkers.dart
+++ b/json_serializable/lib/src/shared_checkers.dart
@@ -43,10 +43,12 @@ String asStatement(DartType type) {
     return '';
   }
 
+  final nullableSuffix = type.isNullableType ? '?' : '';
+
   if (coreIterableTypeChecker.isAssignableFromType(type)) {
     final itemType = coreIterableGenericType(type);
     if (isLikeDynamic(itemType)) {
-      return ' as List';
+      return ' as List$nullableSuffix';
     }
   }
 
@@ -55,7 +57,7 @@ String asStatement(DartType type) {
     assert(args.length == 2);
 
     if (args.every(isLikeDynamic)) {
-      return ' as Map';
+      return ' as Map$nullableSuffix';
     }
   }
 

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,9 +1,9 @@
 name: json_serializable
-version: 4.0.1
+version: 4.0.2
 description: >-
   Automatically generate code for converting to and from JSON by annotating
   Dart classes.
-repository: https://github.com/google/json_serializable.dart
+repository: https://github.com/google/json_serializable.dart/tree/master/json_serializable
 environment:
   # Keeping this <2.12.0 because the code is not null safe – yet!
   sdk: '>=2.11.99 <3.0.0'

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -47,6 +47,7 @@ const _expectedAnnotatedTests = {
   'FinalFields',
   'FinalFieldsNotSetInCtor',
   'FromDynamicCollection',
+  'FromNullableDynamicCollection',
   'GeneralTestClass1',
   'GeneralTestClass2',
   'GenericArgumentFactoriesFlagWithoutGenericType',

--- a/json_serializable/test/src/to_from_json_test_input.dart
+++ b/json_serializable/test/src/to_from_json_test_input.dart
@@ -170,6 +170,35 @@ class FromDynamicCollection {
   late String iterableField;
 }
 
+String _fromNullableDynamicMap(Map? input) => '';
+
+String _fromNullableDynamicList(List? input) => 'null';
+
+String _fromNullableDynamicIterable(Iterable? input) => 'null';
+
+@ShouldGenerate(
+  r'''
+FromNullableDynamicCollection _$FromNullableDynamicCollectionFromJson(
+    Map<String, dynamic> json) {
+  return FromNullableDynamicCollection()
+    ..mapField = _fromNullableDynamicMap(json['mapField'] as Map?)
+    ..listField = _fromNullableDynamicList(json['listField'] as List?)
+    ..iterableField =
+        _fromNullableDynamicIterable(json['iterableField'] as List?);
+}
+''',
+  configurations: ['default'],
+)
+@JsonSerializable(createToJson: false)
+class FromNullableDynamicCollection {
+  @JsonKey(fromJson: _fromNullableDynamicMap)
+  late String mapField;
+  @JsonKey(fromJson: _fromNullableDynamicList)
+  late String listField;
+  @JsonKey(fromJson: _fromNullableDynamicIterable)
+  late String iterableField;
+}
+
 String _noArgs() => throw UnimplementedError();
 
 @ShouldThrow(


### PR DESCRIPTION
..exposed by both class- and function-based converters

Release v4.0.2
