### PR TITLE
checked_yaml: improve handling of missing keys

### DIFF
--- a/checked_yaml/CHANGELOG.md
+++ b/checked_yaml/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.1
+
+- If `CheckedFromJsonException` is caught for a key missing in the source map,
+  include those details in the thrown `ParsedYamlException`.
+
+- Correctly handle the case where `CheckedFromJsonException.message` is `null`.
+
 ## 2.0.0
 
 - *BREAKING* `checkedYamlDecode` `sourceUrl` parameter is now a `Uri`.

--- a/checked_yaml/README.md
+++ b/checked_yaml/README.md
@@ -18,7 +18,6 @@ for the class annotation.
 class Configuration {
   @JsonKey(required: true)
   final String name;
-  @JsonKey(required: true)
   final int count;
 
   Configuration({required this.name, required this.count}) {

--- a/checked_yaml/example/example.dart
+++ b/checked_yaml/example/example.dart
@@ -17,7 +17,6 @@ part 'example.g.dart';
 class Configuration {
   @JsonKey(required: true)
   final String name;
-  @JsonKey(required: true)
   final int count;
 
   Configuration({required this.name, required this.count}) {

--- a/checked_yaml/example/example.g.dart
+++ b/checked_yaml/example/example.g.dart
@@ -9,8 +9,7 @@ part of 'example.dart';
 Configuration _$ConfigurationFromJson(Map json) {
   return $checkedNew('Configuration', json, () {
     $checkKeys(json,
-        allowedKeys: const ['name', 'count'],
-        requiredKeys: const ['name', 'count']);
+        allowedKeys: const ['name', 'count'], requiredKeys: const ['name']);
     final val = Configuration(
       name: $checkedConvert(json, 'name', (v) => v as String),
       count: $checkedConvert(json, 'count', (v) => v as int),

--- a/checked_yaml/lib/checked_yaml.dart
+++ b/checked_yaml/lib/checked_yaml.dart
@@ -75,12 +75,18 @@ ParsedYamlException toParsedYamlException(
       innerError: exception,
     );
   } else {
-    final yamlValue = yamlMap.nodes[exception.key];
-
-    if (yamlValue == null) {
-      // TODO: test this case!
+    if (exception.key == null) {
       return ParsedYamlException(
-        exception.message!,
+        exception.message ?? 'There was an error parsing the map.',
+        yamlMap,
+        innerError: exception,
+      );
+    } else if (!yamlMap.containsKey(exception.key)) {
+      return ParsedYamlException(
+        [
+          'Missing key "${exception.key}".',
+          if (exception.message != null) exception.message!,
+        ].join(' '),
         yamlMap,
         innerError: exception,
       );
@@ -91,7 +97,7 @@ ParsedYamlException toParsedYamlException(
       }
       return ParsedYamlException(
         message,
-        yamlValue,
+        yamlMap.nodes[exception.key] ?? yamlMap,
         innerError: exception,
       );
     }

--- a/checked_yaml/pubspec.yaml
+++ b/checked_yaml/pubspec.yaml
@@ -1,5 +1,5 @@
 name: checked_yaml
-version: 2.0.0
+version: 2.0.1
 
 description: >-
   Generate more helpful exceptions when decoding YAML documents using
@@ -19,7 +19,7 @@ dev_dependencies:
   json_serializable: ^4.0.0
   path: ^1.0.0
   test: ^1.16.0
-  test_process: ^1.0.1
+  test_process: ^2.0.0
 
 dependency_overrides:
   # Need to update dependencies on these packages

--- a/checked_yaml/test/custom_error_test.dart
+++ b/checked_yaml/test/custom_error_test.dart
@@ -1,0 +1,42 @@
+import 'package:checked_yaml/checked_yaml.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  test('bob', () {
+    expect(
+      () => checkedYamlDecode(
+        '{"innerMap": {}}',
+        (m) {
+          throw CheckedFromJsonException(
+            m!['innerMap'] as YamlMap,
+            null,
+            'nothing',
+            null,
+          );
+        },
+      ),
+      throwsA(
+        isA<ParsedYamlException>()
+            .having(
+              (e) => e.message,
+              'message',
+              'There was an error parsing the map.',
+            )
+            .having((e) => e.yamlNode, 'yamlNode', isA<YamlMap>())
+            .having(
+              (e) => e.innerError,
+              'innerError',
+              isA<CheckedFromJsonException>(),
+            )
+            .having((e) => e.formattedMessage, 'formattedMessage', '''
+line 1, column 14: There was an error parsing the map.
+  ╷
+1 │ {"innerMap": {}}
+  │              ^^
+  ╵'''),
+      ),
+    );
+  });
+}

--- a/checked_yaml/test/example_test.dart
+++ b/checked_yaml/test/example_test.dart
@@ -21,10 +21,22 @@ Configuration: {name: bob, count: 42}
     _expectThrows(
       '{}',
       r'''
-line 1, column 1: Required keys are missing: name, count.
+line 1, column 1: Required keys are missing: name.
   ╷
 1 │ {}
   │ ^^
+  ╵''',
+    );
+  });
+
+  test('missing count', () {
+    _expectThrows(
+      '{"name":"something"}',
+      r'''
+line 1, column 1: Missing key "count". type 'Null' is not a subtype of type 'int' in type cast
+  ╷
+1 │ {"name":"something"}
+  │ ^^^^^^^^^^^^^^^^^^^^
   ╵''',
     );
   });
@@ -103,10 +115,17 @@ line 1, column 10: Unsupported value for "name". Cannot be empty.
 }
 
 void _expectThrows(String yamlContent, matcher) => expect(
-    () => _run(yamlContent),
-    throwsA(isA<ParsedYamlException>().having((e) {
-      printOnFailure("r'''\n${e.formattedMessage}'''");
-      return e.formattedMessage;
-    }, 'formattedMessage', matcher)));
+      () => _run(yamlContent),
+      throwsA(
+        isA<ParsedYamlException>().having(
+          (e) {
+            printOnFailure("r'''\n${e.formattedMessage}'''");
+            return e.formattedMessage;
+          },
+          'formattedMessage',
+          matcher,
+        ),
+      ),
+    );
 
 void _run(String yamlContent) => example.main([yamlContent]);

--- a/checked_yaml/test/readme_test.dart
+++ b/checked_yaml/test/readme_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:convert';
 import 'dart:io';
 
@@ -61,9 +59,13 @@ $errorContent
 ```'''));
 
     final proc = await TestProcess.start(
-        Platform.resolvedExecutable, [_examplePath, inputContent]);
+      Platform.resolvedExecutable,
+      [_examplePath, inputContent],
+    );
     await expectLater(
-        proc.stderr, emitsInOrder(LineSplitter.split(errorContent)));
+      proc.stderr,
+      emitsInOrder(LineSplitter.split(errorContent)),
+    );
 
     await proc.shouldExit(isNot(0));
   });


### PR DESCRIPTION
If a CheckedFromJsonException exception is caught for a key that is missing
in the source map, include that information in the message

Also correctly handle the case where CheckedFromJsonException.message
is `null`

Fixes https://github.com/google/json_serializable.dart/issues/816
