### PR TITLE
Use classes with non-nullable fields for core generator classes

### DIFF
--- a/json_annotation/CHANGELOG.md
+++ b/json_annotation/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix a potential error with `checked: true` when `ArgumentError.message` is 
   `null`.
 - Updated `JsonSerializable.fromJson` to handle `null` values.
+- Deprecate `JsonSerializable` `defaults` and `withDefaults()`.
 
 ## 4.0.0
 

--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -194,6 +194,7 @@ class JsonSerializable {
 
   /// An instance of [JsonSerializable] with all fields set to their default
   /// values.
+  @Deprecated('Was only ever included to support builder infrastructure.')
   static const defaults = JsonSerializable(
     anyMap: false,
     checked: false,
@@ -212,6 +213,7 @@ class JsonSerializable {
   ///
   /// Otherwise, the returned value has the default value as defined in
   /// [defaults].
+  @Deprecated('Was only ever included to support builder infrastructure.')
   JsonSerializable withDefaults() => JsonSerializable(
         anyMap: anyMap ?? defaults.anyMap,
         checked: checked ?? defaults.checked,

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -4,6 +4,11 @@
 - Correctly handle nullable generic fields (`T?`) with
   `genericArgumentFactories`.
 
+- `type_helper.dart` - **BREAKING changes**
+  - The API is now null-safe.
+  - new `KeyConfig` class replaces `JsonKey`.
+  - new `ClassConfig` class replaces `JsonSerializable`.
+
 ## 4.0.3
 
 - Correctly handle nullable values with `genericArgumentFactories`.

--- a/json_serializable/lib/src/decode_helper.dart
+++ b/json_serializable/lib/src/decode_helper.dart
@@ -25,15 +25,15 @@ abstract class DecodeHelper implements HelperCore {
     Map<String, FieldElement> accessibleFields,
     Map<String, String> unavailableReasons,
   ) {
-    assert(config.createFactory!);
+    assert(config.createFactory);
     final buffer = StringBuffer();
 
-    final mapType = config.anyMap! ? 'Map' : 'Map<String, dynamic>';
+    final mapType = config.anyMap ? 'Map' : 'Map<String, dynamic>';
     buffer.write('$targetClassReference '
         '${prefix}FromJson${genericClassArgumentsImpl(true)}'
         '($mapType json');
 
-    if (config.genericArgumentFactories!) {
+    if (config.genericArgumentFactories) {
       for (var arg in element.typeParameters) {
         final helperName = fromJsonForType(
           arg.instantiate(nullabilitySuffix: NullabilitySuffix.none),
@@ -72,7 +72,7 @@ abstract class DecodeHelper implements HelperCore {
     final checks = _checkKeys(accessibleFields.values
         .where((fe) => data.usedCtorParamsAndFields.contains(fe.name)));
 
-    if (config.checked!) {
+    if (config.checked) {
       final classLiteral = escapeDartString(element.name);
 
       buffer..write('''
@@ -131,14 +131,14 @@ abstract class DecodeHelper implements HelperCore {
     String constantList(Iterable<FieldElement> things) =>
         'const ${jsonLiteralAsDart(things.map(nameAccess).toList())}';
 
-    if (config.disallowUnrecognizedKeys!) {
+    if (config.disallowUnrecognizedKeys) {
       final allowKeysLiteral = constantList(accessibleFields);
 
       args.add('allowedKeys: $allowKeysLiteral');
     }
 
     final requiredKeys =
-        accessibleFields.where((fe) => jsonKeyFor(fe).required!).toList();
+        accessibleFields.where((fe) => jsonKeyFor(fe).required).toList();
     if (requiredKeys.isNotEmpty) {
       final requiredKeyLiteral = constantList(requiredKeys);
 
@@ -146,7 +146,7 @@ abstract class DecodeHelper implements HelperCore {
     }
 
     final disallowNullKeys = accessibleFields
-        .where((fe) => jsonKeyFor(fe).disallowNullValue!)
+        .where((fe) => jsonKeyFor(fe).disallowNullValue)
         .toList();
     if (disallowNullKeys.isNotEmpty) {
       final disallowNullKeyLiteral = constantList(disallowNullKeys);
@@ -173,7 +173,7 @@ abstract class DecodeHelper implements HelperCore {
 
     String value;
     try {
-      if (config.checked!) {
+      if (config.checked) {
         value = contextHelper
             .deserialize(
               targetType,
@@ -204,7 +204,7 @@ abstract class DecodeHelper implements HelperCore {
     final jsonKey = jsonKeyFor(field);
     final defaultValue = jsonKey.defaultValue;
     if (defaultValue != null) {
-      if (jsonKey.disallowNullValue! && jsonKey.required!) {
+      if (jsonKey.disallowNullValue && jsonKey.required) {
         log.warning('The `defaultValue` on field `${field.name}` will have no '
             'effect because both `disallowNullValue` and `required` are set to '
             '`true`.');

--- a/json_serializable/lib/src/encoder_helper.dart
+++ b/json_serializable/lib/src/encoder_helper.dart
@@ -17,7 +17,7 @@ abstract class EncodeHelper implements HelperCore {
   String _fieldAccess(FieldElement field) => '$_toJsonParamName.${field.name}';
 
   Iterable<String> createToJson(Set<FieldElement> accessibleFields) sync* {
-    assert(config.createToJson!);
+    assert(config.createToJson);
 
     final buffer = StringBuffer();
 
@@ -25,7 +25,7 @@ abstract class EncodeHelper implements HelperCore {
     buffer.write('Map<String, dynamic> '
         '$functionName($targetClassReference $_toJsonParamName');
 
-    if (config.genericArgumentFactories!) {
+    if (config.genericArgumentFactories) {
       for (var arg in element.typeParameters) {
         final helperName = toJsonForType(
           arg.instantiate(nullabilitySuffix: NullabilitySuffix.none),
@@ -140,7 +140,7 @@ abstract class EncodeHelper implements HelperCore {
   bool _writeJsonValueNaive(FieldElement field) {
     final jsonKey = jsonKeyFor(field);
 
-    return jsonKey.includeIfNull! ||
+    return jsonKey.includeIfNull ||
         (!field.type.isNullableType && !_fieldHasCustomEncoder(field));
   }
 

--- a/json_serializable/lib/src/generator_helper.dart
+++ b/json_serializable/lib/src/generator_helper.dart
@@ -41,7 +41,7 @@ class GeneratorHelper extends HelperCore with EncodeHelper, DecodeHelper {
   Iterable<String> generate() sync* {
     assert(_addedMembers.isEmpty);
 
-    if (config.genericArgumentFactories! && element.typeParameters.isEmpty) {
+    if (config.genericArgumentFactories && element.typeParameters.isEmpty) {
       log.warning(
         'The class `${element.displayName}` is annotated '
         'with `JsonSerializable` field `genericArgumentFactories: true`. '
@@ -68,7 +68,7 @@ class GeneratorHelper extends HelperCore with EncodeHelper, DecodeHelper {
           unavailableReasons[field.name] =
               'Setter-only properties are not supported.';
           log.warning('Setters are ignored: ${element.name}.${field.name}');
-        } else if (jsonKeyFor(field).ignore!) {
+        } else if (jsonKeyFor(field).ignore) {
           unavailableReasons[field.name] =
               'It is assigned to an ignored field.';
         } else {
@@ -81,7 +81,7 @@ class GeneratorHelper extends HelperCore with EncodeHelper, DecodeHelper {
     );
 
     var accessibleFieldSet = accessibleFields.values.toSet();
-    if (config.createFactory!) {
+    if (config.createFactory) {
       final createResult = createFactory(accessibleFields, unavailableReasons);
       yield createResult.output;
 
@@ -108,7 +108,7 @@ class GeneratorHelper extends HelperCore with EncodeHelper, DecodeHelper {
       },
     );
 
-    if (config.createToJson!) {
+    if (config.createToJson) {
       yield* createToJson(accessibleFieldSet);
     }
 

--- a/json_serializable/lib/src/helper_core.dart
+++ b/json_serializable/lib/src/helper_core.dart
@@ -4,7 +4,6 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -12,12 +11,13 @@ import 'constants.dart';
 import 'json_key_utils.dart';
 import 'type_helper.dart';
 import 'type_helper_ctx.dart';
+import 'type_helpers/config_types.dart';
 import 'unsupported_type_error.dart';
 import 'utils.dart';
 
 abstract class HelperCore {
   final ClassElement element;
-  final JsonSerializable config;
+  final ClassConfig config;
 
   HelperCore(this.element, this.config);
 
@@ -30,7 +30,7 @@ abstract class HelperCore {
       '${element.name}${genericClassArgumentsImpl(false)}';
 
   @protected
-  String nameAccess(FieldElement field) => jsonKeyFor(field).name!;
+  String nameAccess(FieldElement field) => jsonKeyFor(field).name;
 
   @protected
   String safeNameAccess(FieldElement field) =>
@@ -48,7 +48,7 @@ abstract class HelperCore {
       genericClassArguments(element, withConstraints);
 
   @protected
-  JsonKey jsonKeyFor(FieldElement field) => jsonKeyForField(field, config);
+  KeyConfig jsonKeyFor(FieldElement field) => jsonKeyForField(field, config);
 
   @protected
   TypeHelperCtx getHelperContext(FieldElement field) =>

--- a/json_serializable/lib/src/json_key_utils.dart
+++ b/json_serializable/lib/src/json_key_utils.dart
@@ -10,14 +10,15 @@ import 'package:source_gen/source_gen.dart';
 
 import 'json_literal_generator.dart';
 import 'shared_checkers.dart';
+import 'type_helpers/config_types.dart';
 import 'utils.dart';
 
-final _jsonKeyExpando = Expando<JsonKey>();
+final _jsonKeyExpando = Expando<KeyConfig>();
 
-JsonKey jsonKeyForField(FieldElement field, JsonSerializable classAnnotation) =>
+KeyConfig jsonKeyForField(FieldElement field, ClassConfig classAnnotation) =>
     _jsonKeyExpando[field] ??= _from(field, classAnnotation);
 
-JsonKey _from(FieldElement element, JsonSerializable classAnnotation) {
+KeyConfig _from(FieldElement element, ClassConfig classAnnotation) {
   // If an annotation exists on `element` the source is a 'real' field.
   // If the result is `null`, check the getter – it is a property.
   // TODO: setters: github.com/google/json_serializable.dart/issues/24
@@ -183,8 +184,8 @@ JsonKey _from(FieldElement element, JsonSerializable classAnnotation) {
   );
 }
 
-JsonKey _populateJsonKey(
-  JsonSerializable classAnnotation,
+KeyConfig _populateJsonKey(
+  ClassConfig classAnnotation,
   FieldElement element, {
   Object? defaultValue,
   bool? disallowNullValue,
@@ -203,7 +204,7 @@ JsonKey _populateJsonKey(
     }
   }
 
-  final jsonKey = JsonKey(
+  return KeyConfig(
     defaultValue: defaultValue,
     disallowNullValue: disallowNullValue ?? false,
     ignore: ignore ?? false,
@@ -213,8 +214,6 @@ JsonKey _populateJsonKey(
     required: required ?? false,
     unknownEnumValue: unknownEnumValue,
   );
-
-  return jsonKey;
 }
 
 String _encodedFieldName(
@@ -245,10 +244,10 @@ String _encodedFieldName(
   }
 }
 
-bool? _includeIfNull(
+bool _includeIfNull(
   bool? keyIncludeIfNull,
   bool? keyDisallowNullValue,
-  bool? classIncludeIfNull,
+  bool classIncludeIfNull,
 ) {
   if (keyDisallowNullValue == true) {
     assert(keyIncludeIfNull != true);

--- a/json_serializable/lib/src/settings.dart
+++ b/json_serializable/lib/src/settings.dart
@@ -6,6 +6,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 import 'type_helper.dart';
 import 'type_helpers/big_int_helper.dart';
+import 'type_helpers/config_types.dart';
 import 'type_helpers/convert_helper.dart';
 import 'type_helpers/date_time_helper.dart';
 import 'type_helpers/duration_helper.dart';
@@ -44,7 +45,24 @@ class Settings {
 
   final JsonSerializable _config;
 
-  JsonSerializable get config => _config.withDefaults();
+  ClassConfig get config => ClassConfig(
+        checked: _config.checked ?? ClassConfig.defaults.checked,
+        anyMap: _config.anyMap ?? ClassConfig.defaults.anyMap,
+        createFactory:
+            _config.createFactory ?? ClassConfig.defaults.createFactory,
+        createToJson: _config.createToJson ?? ClassConfig.defaults.createToJson,
+        ignoreUnannotated:
+            _config.ignoreUnannotated ?? ClassConfig.defaults.ignoreUnannotated,
+        explicitToJson:
+            _config.explicitToJson ?? ClassConfig.defaults.explicitToJson,
+        includeIfNull:
+            _config.includeIfNull ?? ClassConfig.defaults.includeIfNull,
+        genericArgumentFactories: _config.genericArgumentFactories ??
+            ClassConfig.defaults.genericArgumentFactories,
+        fieldRename: _config.fieldRename ?? ClassConfig.defaults.fieldRename,
+        disallowUnrecognizedKeys: _config.disallowUnrecognizedKeys ??
+            ClassConfig.defaults.disallowUnrecognizedKeys,
+      );
 
   /// Creates an instance of [Settings].
   ///
@@ -54,7 +72,7 @@ class Settings {
   const Settings({
     JsonSerializable? config,
     List<TypeHelper>? typeHelpers,
-  })  : _config = config ?? JsonSerializable.defaults,
+  })  : _config = config ?? ClassConfig.defaults,
         _typeHelpers = typeHelpers ?? defaultHelpers;
 
   /// Creates an instance of [Settings].

--- a/json_serializable/lib/src/type_helper.dart
+++ b/json_serializable/lib/src/type_helper.dart
@@ -4,7 +4,8 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:json_annotation/json_annotation.dart';
+
+import 'type_helpers/config_types.dart';
 
 /// Context information provided in calls to [TypeHelper.serialize] and
 /// [TypeHelper.deserialize].
@@ -30,7 +31,7 @@ abstract class TypeHelperContext {
 /// Extended context information with includes configuration values
 /// corresponding to `JsonSerializableGenerator` settings.
 abstract class TypeHelperContextWithConfig extends TypeHelperContext {
-  JsonSerializable get config;
+  ClassConfig get config;
 }
 
 abstract class TypeHelper<T extends TypeHelperContext> {

--- a/json_serializable/lib/src/type_helper_ctx.dart
+++ b/json_serializable/lib/src/type_helper_ctx.dart
@@ -5,10 +5,10 @@
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:json_annotation/json_annotation.dart';
 
 import 'helper_core.dart';
 import 'type_helper.dart';
+import 'type_helpers/config_types.dart';
 import 'type_helpers/convert_helper.dart';
 import 'unsupported_type_error.dart';
 import 'utils.dart';
@@ -28,7 +28,7 @@ class TypeHelperCtx
   ClassElement get classElement => _helperCore.element;
 
   @override
-  JsonSerializable get config => _helperCore.config;
+  ClassConfig get config => _helperCore.config;
 
   TypeHelperCtx._(this._helperCore, this.fieldElement);
 

--- a/json_serializable/lib/src/type_helpers/config_types.dart
+++ b/json_serializable/lib/src/type_helpers/config_types.dart
@@ -1,0 +1,123 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:json_annotation/json_annotation.dart';
+
+/// Represents values from [JsonKey] when merged with local configuration.
+class KeyConfig {
+  final Object? defaultValue;
+
+  final bool disallowNullValue;
+
+  final bool ignore;
+
+  final bool includeIfNull;
+
+  final String name;
+
+  final bool required;
+
+  final Object? unknownEnumValue;
+
+  KeyConfig({
+    required this.defaultValue,
+    required this.disallowNullValue,
+    required this.ignore,
+    required this.includeIfNull,
+    required this.name,
+    required this.required,
+    required this.unknownEnumValue,
+  });
+}
+
+/// Represents values from [JsonSerializable] when merged with local
+/// configuration.
+///
+/// Values are all known, so types are non-nullable.
+class ClassConfig implements JsonSerializable {
+  @override
+  final bool anyMap;
+
+  @override
+  final bool checked;
+
+  @override
+  final bool createFactory;
+
+  @override
+  final bool createToJson;
+
+  @override
+  final bool disallowUnrecognizedKeys;
+
+  @override
+  final bool explicitToJson;
+
+  @override
+  final FieldRename fieldRename;
+
+  @override
+  final bool genericArgumentFactories;
+
+  @override
+  final bool ignoreUnannotated;
+
+  @override
+  final bool includeIfNull;
+
+  const ClassConfig({
+    required this.anyMap,
+    required this.checked,
+    required this.createFactory,
+    required this.createToJson,
+    required this.disallowUnrecognizedKeys,
+    required this.explicitToJson,
+    required this.fieldRename,
+    required this.genericArgumentFactories,
+    required this.ignoreUnannotated,
+    required this.includeIfNull,
+  });
+
+  /// An instance of [JsonSerializable] with all fields set to their default
+  /// values.
+  static const defaults = ClassConfig(
+    anyMap: false,
+    checked: false,
+    createFactory: true,
+    createToJson: true,
+    disallowUnrecognizedKeys: false,
+    explicitToJson: false,
+    fieldRename: FieldRename.none,
+    genericArgumentFactories: false,
+    ignoreUnannotated: false,
+    includeIfNull: true,
+  );
+
+  @override
+  Map<String, dynamic> toJson() => _$JsonSerializableToJson(this);
+
+  @override
+  JsonSerializable withDefaults() => this;
+}
+
+const _$FieldRenameEnumMap = {
+  FieldRename.none: 'none',
+  FieldRename.kebab: 'kebab',
+  FieldRename.snake: 'snake',
+  FieldRename.pascal: 'pascal',
+};
+
+Map<String, dynamic> _$JsonSerializableToJson(JsonSerializable instance) =>
+    <String, dynamic>{
+      'any_map': instance.anyMap,
+      'checked': instance.checked,
+      'create_factory': instance.createFactory,
+      'create_to_json': instance.createToJson,
+      'disallow_unrecognized_keys': instance.disallowUnrecognizedKeys,
+      'explicit_to_json': instance.explicitToJson,
+      'field_rename': _$FieldRenameEnumMap[instance.fieldRename],
+      'generic_argument_factories': instance.genericArgumentFactories,
+      'ignore_unannotated': instance.ignoreUnannotated,
+      'include_if_null': instance.includeIfNull,
+    };

--- a/json_serializable/lib/src/type_helpers/generic_factory_helper.dart
+++ b/json_serializable/lib/src/type_helpers/generic_factory_helper.dart
@@ -17,7 +17,7 @@ class GenericFactoryHelper extends TypeHelper<TypeHelperContextWithConfig> {
     String expression,
     TypeHelperContextWithConfig context,
   ) {
-    if (context.config.genericArgumentFactories! &&
+    if (context.config.genericArgumentFactories &&
         targetType is TypeParameterType) {
       final toJsonFunc = toJsonForType(targetType);
       if (targetType.isNullableType) {
@@ -38,7 +38,7 @@ class GenericFactoryHelper extends TypeHelper<TypeHelperContextWithConfig> {
     TypeHelperContextWithConfig context,
     bool defaultProvided,
   ) {
-    if (context.config.genericArgumentFactories! &&
+    if (context.config.genericArgumentFactories &&
         targetType is TypeParameterType) {
       final fromJsonFunc = fromJsonForType(targetType);
 

--- a/json_serializable/lib/src/type_helpers/json_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_helper.dart
@@ -12,6 +12,7 @@ import 'package:source_gen/source_gen.dart';
 import '../shared_checkers.dart';
 import '../type_helper.dart';
 import '../utils.dart';
+import 'config_types.dart';
 import 'generic_factory_helper.dart';
 
 const _helperLambdaParam = 'value';
@@ -55,7 +56,7 @@ class JsonHelper extends TypeHelper<TypeHelperContextWithConfig> {
       );
     }
 
-    if (context.config.explicitToJson! || toJsonArgs.isNotEmpty) {
+    if (context.config.explicitToJson || toJsonArgs.isNotEmpty) {
       return '$expression${interfaceType.isNullableType ? '?' : ''}'
           '.toJson(${toJsonArgs.map((a) => '$a, ').join()} )';
     }
@@ -116,7 +117,7 @@ class JsonHelper extends TypeHelper<TypeHelperContextWithConfig> {
 
       output = args.join(', ');
     } else if (_annotation(context.config, targetType)?.createFactory == true) {
-      if (context.config.anyMap!) {
+      if (context.config.anyMap) {
         output += ' as Map';
       } else {
         output += ' as Map<String, dynamic>';
@@ -219,7 +220,7 @@ TypeParameterType _encodeHelper(
   );
 }
 
-bool _canSerialize(JsonSerializable config, DartType type) {
+bool _canSerialize(ClassConfig config, DartType type) {
   if (type is InterfaceType) {
     final toJsonMethod = _toJsonMethod(type);
 
@@ -266,7 +267,7 @@ InterfaceType? _instantiate(
   );
 }
 
-JsonSerializable? _annotation(JsonSerializable config, InterfaceType source) {
+ClassConfig? _annotation(ClassConfig config, InterfaceType source) {
   final annotations = const TypeChecker.fromRuntime(JsonSerializable)
       .annotationsOfExact(source.element, throwOnUnresolved: false)
       .toList();

--- a/json_serializable/lib/src/type_helpers/map_helper.dart
+++ b/json_serializable/lib/src/type_helpers/map_helper.dart
@@ -77,7 +77,7 @@ class MapHelper extends TypeHelper<TypeHelperContextWithConfig> {
 
     if (!isKeyStringable) {
       if (valueArgIsAny) {
-        if (context.config.anyMap!) {
+        if (context.config.anyMap) {
           if (isLikeDynamic(keyArg)) {
             return '$expression as Map$optionalQuestion';
           }
@@ -102,7 +102,7 @@ class MapHelper extends TypeHelper<TypeHelperContextWithConfig> {
 
     final itemSubVal = context.deserialize(valueArg, closureArg);
 
-    var mapCast = context.config.anyMap! ? 'as Map' : 'as Map<String, dynamic>';
+    var mapCast = context.config.anyMap ? 'as Map' : 'as Map<String, dynamic>';
 
     if (targetTypeIsNullable) {
       mapCast += '?';
@@ -111,10 +111,10 @@ class MapHelper extends TypeHelper<TypeHelperContextWithConfig> {
     String keyUsage;
     if (isEnum(keyArg)) {
       keyUsage = context.deserialize(keyArg, _keyParam).toString();
-    } else if (context.config.anyMap! &&
+    } else if (context.config.anyMap &&
         !(keyArg.isDartCoreObject || keyArg.isDynamic)) {
       keyUsage = '$_keyParam as String';
-    } else if (context.config.anyMap! &&
+    } else if (context.config.anyMap &&
         keyArg.isDartCoreObject &&
         !keyArg.isNullableType) {
       keyUsage = '$_keyParam as Object';

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -10,6 +10,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:source_gen/source_gen.dart';
 
 import 'helper_core.dart';
+import 'type_helpers/config_types.dart';
 
 const _jsonKeyChecker = TypeChecker.fromRuntime(JsonKey);
 
@@ -97,14 +98,14 @@ JsonSerializable _valueForAnnotation(ConstantReader reader) => JsonSerializable(
 /// Note: if [JsonSerializable.genericArgumentFactories] is `false` for [reader]
 /// and `true` for [config], the corresponding field in the return value will
 /// only be `true` if [classElement] has type parameters.
-JsonSerializable mergeConfig(
-  JsonSerializable config,
+ClassConfig mergeConfig(
+  ClassConfig config,
   ConstantReader reader, {
   required ClassElement classElement,
 }) {
   final annotation = _valueForAnnotation(reader);
 
-  return JsonSerializable(
+  return ClassConfig(
     anyMap: annotation.anyMap ?? config.anyMap,
     checked: annotation.checked ?? config.checked,
     createFactory: annotation.createFactory ?? config.createFactory,
@@ -115,7 +116,7 @@ JsonSerializable mergeConfig(
     fieldRename: annotation.fieldRename ?? config.fieldRename,
     genericArgumentFactories: annotation.genericArgumentFactories ??
         (classElement.typeParameters.isNotEmpty &&
-            config.genericArgumentFactories!),
+            config.genericArgumentFactories),
     ignoreUnannotated: annotation.ignoreUnannotated ?? config.ignoreUnannotated,
     includeIfNull: annotation.includeIfNull ?? config.includeIfNull,
   );

--- a/json_serializable/lib/type_helper.dart
+++ b/json_serializable/lib/type_helper.dart
@@ -6,6 +6,7 @@ export 'src/shared_checkers.dart' show simpleJsonTypeChecker, typeArgumentsOf;
 export 'src/type_helper.dart'
     show TypeHelperContext, TypeHelperContextWithConfig, TypeHelper;
 export 'src/type_helpers/big_int_helper.dart';
+export 'src/type_helpers/config_types.dart';
 export 'src/type_helpers/convert_helper.dart';
 export 'src/type_helpers/date_time_helper.dart';
 export 'src/type_helpers/duration_helper.dart';

--- a/json_serializable/test/custom_configuration_test.dart
+++ b/json_serializable/test/custom_configuration_test.dart
@@ -11,6 +11,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:json_serializable/json_serializable.dart';
 import 'package:json_serializable/src/constants.dart';
 import 'package:json_serializable/src/type_helper.dart';
+import 'package:json_serializable/src/type_helpers/config_types.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_gen/source_gen.dart';
 import 'package:source_gen_test/source_gen_test.dart';
@@ -31,7 +32,7 @@ Future<void> main() async {
   );
 
   group('without wrappers', () {
-    _registerTests(JsonSerializable.defaults);
+    _registerTests(ClassConfig.defaults);
   });
 
   group('configuration', () {

--- a/json_serializable/test/shared_config.dart
+++ b/json_serializable/test/shared_config.dart
@@ -3,11 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:json_annotation/json_annotation.dart';
+import 'package:json_serializable/src/type_helpers/config_types.dart';
 
 final jsonSerializableFields = generatorConfigDefaultJson.keys.toList();
 
 final generatorConfigDefaultJson = Map<String, dynamic>.unmodifiable(
-    const JsonSerializable().withDefaults().toJson());
+    ClassConfig.defaults.withDefaults().toJson());
 
 final generatorConfigNonDefaultJson =
     Map<String, dynamic>.unmodifiable(const JsonSerializable(


### PR DESCRIPTION
Eliminates most null checks
A breaking change to `type_helper.dart`, but this is only a
pseudo-supported library
