### PR TITLE
Improves private names of functions

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Use the default value for optional constructor parameters if
   `JsonKey.defaultValue` is not provided. This could be a breaking behavior
   change in generated code in some cases.
+- Improve names of private classes' `toJson` and `fromJson`.
 
 ## 4.1.0
 

--- a/json_serializable/lib/src/helper_core.dart
+++ b/json_serializable/lib/src/helper_core.dart
@@ -37,7 +37,7 @@ abstract class HelperCore {
       escapeDartString(nameAccess(field));
 
   @protected
-  String get prefix => '_\$${element.name}';
+  String get prefix => '_\$${nonPrivateName(element.name)}';
 
   /// Returns a [String] representing the type arguments that exist on
   /// [element].

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -52,6 +52,8 @@ String _fixCase(String input, String separator) =>
       return lower;
     });
 
+String nonPrivateName(String input) => input.replaceFirst(RegExp(r'^_*'), '');
+
 Never throwUnsupported(FieldElement element, String message) =>
     throw InvalidGenerationSourceError(
         'Error with `@JsonKey` on `${element.name}`. $message',

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -29,6 +29,7 @@ const _expectedAnnotatedTests = {
   'BadOneNamed',
   'BadToFuncReturnType',
   'BadTwoRequiredPositional',
+  '_BetterPrivateNames',
   'DefaultDoubleConstants',
   'DefaultWithConstObject',
   'DefaultWithDisallowNullRequiredClass',

--- a/json_serializable/test/src/to_from_json_test_input.dart
+++ b/json_serializable/test/src/to_from_json_test_input.dart
@@ -262,3 +262,24 @@ class OkayOnlyOptionalPositional {
   @JsonKey(fromJson: _onlyOptionalPositional)
   String? field;
 }
+
+@ShouldGenerate(
+  r'''
+_BetterPrivateNames _$BetterPrivateNamesFromJson(Map<String, dynamic> json) {
+  return _BetterPrivateNames(
+    name: json['name'] as String,
+  );
+}
+
+Map<String, dynamic> _$BetterPrivateNamesToJson(_BetterPrivateNames instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+    };
+''',
+)
+@JsonSerializable(createFactory: true, createToJson: true)
+// ignore: unused_element
+class _BetterPrivateNames {
+  final String name;
+  _BetterPrivateNames({required this.name});
+}

--- a/json_serializable/test/utils_test.dart
+++ b/json_serializable/test/utils_test.dart
@@ -50,4 +50,15 @@ void main() {
       });
     }
   });
+
+  group('nonPrivateName', () {
+    test('removes leading underscores', () {
+      final name = nonPrivateName('__hello__world__');
+      expect(name, equals('hello__world__'));
+    });
+    test('does not changes public names', () {
+      final name = nonPrivateName('HelloWorld');
+      expect(name, equals('HelloWorld'));
+    });
+  });
 }


### PR DESCRIPTION
Changes naming of `toJson` and `fromJson` such that this:
```dart
class _Person {
  // ...
}
```
generates this:
```dart
_Person _$PersonFromJson(Map<String, dynamic> json) {}
Map<String, dynamic> _$PersonToJson(Person instance) {}
```
instead of this:
```dart
_Person _$_PersonFromJson(Map<String, dynamic> json) {}
Map<String, dynamic> _$_PersonToJson(Person instance) {}
```
Closes #619.