### PR TITLE
Correctly handle nullable types with type arguments in generated code (#901)

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -12,6 +12,10 @@
   - **BREAKING**: removed `typeArgumentsOf`. This is now an extension exposed 
     by `package:source_helper`. 
 
+## 4.1.3
+
+- Correctly handle nullable types with type arguments in generated code.
+
 ## 4.1.2
 
 - Correctly decode `Map<String, double>` when the input has `int` literals.

--- a/json_serializable/test/integration/integration_test.dart
+++ b/json_serializable/test/integration/integration_test.dart
@@ -195,8 +195,16 @@ void main() {
       expect(item.saleDates, isNull);
       roundTripItem(item);
 
-      expect(item.toJson().keys, orderedEquals(['price', 'saleDates', 'rates']),
-          reason: 'Omits null `itemNumber`');
+      expect(
+        item.toJson().keys,
+        orderedEquals([
+          'price',
+          'saleDates',
+          'rates',
+          'geoPoint',
+        ]),
+        reason: 'Omits null `itemNumber`',
+      );
     });
 
     test('set itemNumber - with custom JSON key', () {
@@ -204,9 +212,17 @@ void main() {
       expect(item.itemNumber, 42);
       roundTripItem(item);
 
-      expect(item.toJson().keys,
-          orderedEquals(['price', 'item-number', 'saleDates', 'rates']),
-          reason: 'Includes non-null `itemNumber` - with custom key');
+      expect(
+        item.toJson().keys,
+        orderedEquals([
+          'price',
+          'item-number',
+          'saleDates',
+          'rates',
+          'geoPoint',
+        ]),
+        reason: 'Includes non-null `itemNumber` - with custom key',
+      );
     });
   });
 

--- a/json_serializable/test/integration/json_test_example.dart
+++ b/json_serializable/test/integration/json_test_example.dart
@@ -104,6 +104,10 @@ class Item extends ItemCore {
   List<DateTime>? saleDates;
   List<int>? rates;
 
+  // Regression test for https://github.com/google/json_serializable.dart/issues/896
+  @JsonKey(fromJson: _fromJsonGeoPoint, toJson: _toJsonGeoPoint)
+  GeoPoint? geoPoint;
+
   Item([int? price]) : super(price);
 
   factory Item.fromJson(Map<String, dynamic> json) => _$ItemFromJson(json);
@@ -116,6 +120,27 @@ class Item extends ItemCore {
       price == other.price &&
       itemNumber == other.itemNumber &&
       deepEquals(saleDates, other.saleDates);
+}
+
+GeoPoint? _fromJsonGeoPoint(Map<String, dynamic>? json) {
+  if (json != null) {
+    return GeoPoint(json['latitude'], json['longitude']);
+  } else {
+    return null;
+  }
+}
+
+Map<String, dynamic>? _toJsonGeoPoint(GeoPoint? geoPoint) {
+  if (geoPoint == null) {
+    return null;
+  }
+  return {'latitude': geoPoint.latitude, 'longitude': geoPoint.longitude};
+}
+
+class GeoPoint {
+  final Object? latitude, longitude;
+
+  GeoPoint(this.latitude, this.longitude);
 }
 
 @JsonSerializable()

--- a/json_serializable/test/integration/json_test_example.g.dart
+++ b/json_serializable/test/integration/json_test_example.g.dart
@@ -155,8 +155,8 @@ Item _$ItemFromJson(Map<String, dynamic> json) => Item(
       ..saleDates = (json['saleDates'] as List<dynamic>?)
           ?.map((e) => DateTime.parse(e as String))
           .toList()
-      ..rates =
-          (json['rates'] as List<dynamic>?)?.map((e) => e as int).toList();
+      ..rates = (json['rates'] as List<dynamic>?)?.map((e) => e as int).toList()
+      ..geoPoint = _fromJsonGeoPoint(json['geoPoint'] as Map<String, dynamic>?);
 
 Map<String, dynamic> _$ItemToJson(Item instance) {
   final val = <String, dynamic>{
@@ -173,6 +173,7 @@ Map<String, dynamic> _$ItemToJson(Item instance) {
   val['saleDates'] =
       instance.saleDates?.map((e) => e.toIso8601String()).toList();
   val['rates'] = instance.rates;
+  val['geoPoint'] = _toJsonGeoPoint(instance.geoPoint);
   return val;
 }
 

--- a/json_serializable/test/integration/json_test_example.g_any_map.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.dart
@@ -110,6 +110,10 @@ class Item extends ItemCore {
   List<DateTime>? saleDates;
   List<int>? rates;
 
+  // Regression test for https://github.com/google/json_serializable.dart/issues/896
+  @JsonKey(fromJson: _fromJsonGeoPoint, toJson: _toJsonGeoPoint)
+  GeoPoint? geoPoint;
+
   Item([int? price]) : super(price);
 
   factory Item.fromJson(Map<String, dynamic> json) => _$ItemFromJson(json);
@@ -122,6 +126,27 @@ class Item extends ItemCore {
       price == other.price &&
       itemNumber == other.itemNumber &&
       deepEquals(saleDates, other.saleDates);
+}
+
+GeoPoint? _fromJsonGeoPoint(Map<String, dynamic>? json) {
+  if (json != null) {
+    return GeoPoint(json['latitude'], json['longitude']);
+  } else {
+    return null;
+  }
+}
+
+Map<String, dynamic>? _toJsonGeoPoint(GeoPoint? geoPoint) {
+  if (geoPoint == null) {
+    return null;
+  }
+  return {'latitude': geoPoint.latitude, 'longitude': geoPoint.longitude};
+}
+
+class GeoPoint {
+  final Object? latitude, longitude;
+
+  GeoPoint(this.latitude, this.longitude);
 }
 
 @JsonSerializable(

--- a/json_serializable/test/integration/json_test_example.g_any_map.g.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.g.dart
@@ -155,8 +155,8 @@ Item _$ItemFromJson(Map json) => Item(
       ..saleDates = (json['saleDates'] as List<dynamic>?)
           ?.map((e) => DateTime.parse(e as String))
           .toList()
-      ..rates =
-          (json['rates'] as List<dynamic>?)?.map((e) => e as int).toList();
+      ..rates = (json['rates'] as List<dynamic>?)?.map((e) => e as int).toList()
+      ..geoPoint = _fromJsonGeoPoint(json['geoPoint'] as Map<String, dynamic>?);
 
 Map<String, dynamic> _$ItemToJson(Item instance) {
   final val = <String, dynamic>{
@@ -173,6 +173,7 @@ Map<String, dynamic> _$ItemToJson(Item instance) {
   val['saleDates'] =
       instance.saleDates?.map((e) => e.toIso8601String()).toList();
   val['rates'] = instance.rates;
+  val['geoPoint'] = _toJsonGeoPoint(instance.geoPoint);
   return val;
 }
 


### PR DESCRIPTION
Missed a code path where `?` should be included when a type has arguments

Fixes https://github.com/google/json_serializable.dart/issues/896

Prepare to release 4.1.3