### PR TITLE
json_annotation: annotate annotations with the supported targets

### DIFF
--- a/json_annotation/CHANGELOG.md
+++ b/json_annotation/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Added a `const` constructor to `JsonConverter`.
 - Added `$checkedCreate` helper that will be used by `package:json_serializable`
   v5+ and replaces both `$checkedNew` and `$checkedConvert`.
+- Annotate annotations with the supported target types, to minimize incorrect
+  usage.
 
 ## 4.0.1
 

--- a/json_annotation/lib/src/json_key.dart
+++ b/json_annotation/lib/src/json_key.dart
@@ -2,10 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:meta/meta_meta.dart';
+
 import 'allowed_keys_helpers.dart';
 import 'json_serializable.dart';
 
 /// An annotation used to specify how a field is serialized.
+@Target({TargetKind.field, TargetKind.getter})
 class JsonKey {
   /// The value to use if the source JSON does not contain this key or if the
   /// value is `null`.

--- a/json_annotation/lib/src/json_literal.dart
+++ b/json_annotation/lib/src/json_literal.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:meta/meta_meta.dart';
+
 /// An annotation used to generate a private field containing the contents of a
 /// JSON file.
 ///
@@ -15,6 +17,7 @@
 /// @JsonLiteral('data.json')
 /// Map get glossaryData => _$glossaryDataJsonLiteral;
 /// ```
+@Target({TargetKind.getter})
 class JsonLiteral {
   /// The relative path from the Dart file with the annotation to the file
   /// containing the source JSON.

--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:meta/meta_meta.dart';
+
 import 'allowed_keys_helpers.dart';
 import 'checked_helpers.dart';
 import 'json_key.dart';
@@ -29,6 +31,7 @@ enum FieldRename {
   disallowUnrecognizedKeys: true,
   fieldRename: FieldRename.snake,
 )
+@Target({TargetKind.classType})
 class JsonSerializable {
   /// If `true`, [Map] types are *not* assumed to be [Map<String, dynamic>]
   /// – which is the default type of [Map] instances return by JSON decode in

--- a/json_annotation/pubspec.yaml
+++ b/json_annotation/pubspec.yaml
@@ -7,6 +7,9 @@ repository: https://github.com/google/json_serializable.dart
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
+dependencies:
+  meta: ^1.4.0
+
 # When changing JsonSerializable class.
 # dev_dependencies:
 #   build_runner: ^1.0.0

--- a/json_serializable/test/src/_json_serializable_test_input.dart
+++ b/json_serializable/test/src/_json_serializable_test_input.dart
@@ -5,40 +5,28 @@
 import 'dart:collection';
 
 import 'package:json_annotation/json_annotation.dart';
-
 // ignore: import_of_legacy_library_into_null_safe
 import 'package:source_gen_test/annotations.dart';
 
 part 'checked_test_input.dart';
-
 part 'constants_copy.dart';
-
 part 'core_subclass_type_input.dart';
-
 part 'default_value_input.dart';
-
 part 'field_namer_input.dart';
-
 part 'generic_test_input.dart';
-
 part 'inheritance_test_input.dart';
-
 part 'json_converter_test_input.dart';
-
 part 'map_key_variety_test_input.dart';
-
 part 'setter_test_input.dart';
-
 part 'to_from_json_test_input.dart';
-
 part 'unknown_enum_value_test_input.dart';
 
 @ShouldThrow('`@JsonSerializable` can only be used on classes.')
-@JsonSerializable()
+@JsonSerializable() // ignore: invalid_annotation_target
 const theAnswer = 42;
 
 @ShouldThrow('`@JsonSerializable` can only be used on classes.')
-@JsonSerializable()
+@JsonSerializable() // ignore: invalid_annotation_target
 Object annotatedMethod() => throw UnimplementedError();
 
 @ShouldGenerate(


### PR DESCRIPTION
Hopefully minimizes incorrect usage.

Closes https://github.com/google/json_serializable.dart/issues/910
