### PR TITLE
Make compatible with freezed package

### DIFF
--- a/json_annotation/lib/src/json_key.dart
+++ b/json_annotation/lib/src/json_key.dart
@@ -8,7 +8,7 @@ import 'allowed_keys_helpers.dart';
 import 'json_serializable.dart';
 
 /// An annotation used to specify how a field is serialized.
-@Target({TargetKind.field, TargetKind.getter})
+@Target({TargetKind.field, TargetKind.getter, TargetKind.parameter})
 class JsonKey {
   /// The value to use if the source JSON does not contain this key or if the
   /// value is `null`.

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 5.0.1-dev
+version: 5.0.2
 description: >-
   Automatically generate code for converting to and from JSON by annotating
   Dart classes.


### PR DESCRIPTION
Freezed package requires the JsonKey annotation to be inserted into the constructor, which is then copied to the generated classes. But currently this use generates a warning, and this PR adds an additional TargetKind so the warning is no longer generated.