### PR TITLE
Include type arguments when invoking `fromJson` on custom types.

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.0.2
+
+- Include type arguments when invoking `fromJson` on custom types.
+  This fixes an edge case where the generic arguments could not be inferred.
+
 ## 5.0.1
 
 - Correctly handle nullable custom objects within `Iterable` and `Map`.

--- a/json_serializable/lib/src/type_helpers/json_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_helper.dart
@@ -11,6 +11,7 @@ import 'package:source_gen/source_gen.dart';
 import 'package:source_helper/source_helper.dart';
 
 import '../default_container.dart';
+import '../helper_core.dart';
 import '../type_helper.dart';
 import '../utils.dart';
 import 'config_types.dart';
@@ -130,7 +131,7 @@ class JsonHelper extends TypeHelper<TypeHelperContextWithConfig> {
 
     // TODO: the type could be imported from a library with a prefix!
     // https://github.com/google/json_serializable.dart/issues/19
-    output = '${targetType.element.name}.fromJson($output)';
+    output = '${typeToCode(targetType.promoteNonNullable())}.fromJson($output)';
 
     return DefaultContainer(expression, output);
   }

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 5.0.1
+version: 5.0.2
 description: >-
   Automatically generate code for converting to and from JSON by annotating
   Dart classes.

--- a/json_serializable/test/generic_files/generic_argument_factories.g.dart
+++ b/json_serializable/test/generic_files/generic_argument_factories.g.dart
@@ -32,13 +32,15 @@ Map<String, dynamic> _$GenericClassWithHelpersToJson<T, S>(
 
 ConcreteClass _$ConcreteClassFromJson(Map<String, dynamic> json) =>
     ConcreteClass(
-      GenericClassWithHelpers.fromJson(json['value'] as Map<String, dynamic>,
-          (value) => value as int, (value) => value as String),
-      GenericClassWithHelpers.fromJson(
+      GenericClassWithHelpers<int, String>.fromJson(
+          json['value'] as Map<String, dynamic>,
+          (value) => value as int,
+          (value) => value as String),
+      GenericClassWithHelpers<double, BigInt>.fromJson(
           json['value2'] as Map<String, dynamic>,
           (value) => (value as num).toDouble(),
           (value) => BigInt.parse(value as String)),
-      GenericClassWithHelpers.fromJson(
+      GenericClassWithHelpers<double?, BigInt?>.fromJson(
           json['value3'] as Map<String, dynamic>,
           (value) => (value as num?)?.toDouble(),
           (value) => value == null ? null : BigInt.parse(value as String)),

--- a/json_serializable/test/generic_files/generic_argument_factories_nullable.g.dart
+++ b/json_serializable/test/generic_files/generic_argument_factories_nullable.g.dart
@@ -55,15 +55,15 @@ Object? _$nullableGenericToJson<T>(
 ConcreteClassNullable _$ConcreteClassNullableFromJson(
         Map<String, dynamic> json) =>
     ConcreteClassNullable(
-      GenericClassWithHelpersNullable.fromJson(
+      GenericClassWithHelpersNullable<int, String>.fromJson(
           json['value'] as Map<String, dynamic>,
           (value) => value as int,
           (value) => value as String),
-      GenericClassWithHelpersNullable.fromJson(
+      GenericClassWithHelpersNullable<double, BigInt>.fromJson(
           json['value2'] as Map<String, dynamic>,
           (value) => (value as num).toDouble(),
           (value) => BigInt.parse(value as String)),
-      GenericClassWithHelpersNullable.fromJson(
+      GenericClassWithHelpersNullable<double?, BigInt?>.fromJson(
           json['value3'] as Map<String, dynamic>,
           (value) => (value as num?)?.toDouble(),
           (value) => value == null ? null : BigInt.parse(value as String)),

--- a/json_serializable/test/generic_files/generic_class.dart
+++ b/json_serializable/test/generic_files/generic_class.dart
@@ -2,7 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:collection/collection.dart';
 import 'package:json_annotation/json_annotation.dart';
+
+import '../test_utils.dart';
 
 part 'generic_class.g.dart';
 
@@ -102,4 +105,41 @@ class _DurationListMillisecondConverter
   @override
   int? toJson(List<Duration>? object) =>
       object?.fold<int>(0, (sum, obj) => sum + obj.inMilliseconds);
+}
+
+class Issue980GenericClass<T> {
+  final T value;
+
+  Issue980GenericClass(this.value);
+
+  factory Issue980GenericClass.fromJson(Map<String, dynamic> json) =>
+      Issue980GenericClass(json['value'] as T);
+
+  Map<String, dynamic> toJson() => {'value': value};
+
+  @override
+  bool operator ==(Object other) =>
+      other is Issue980GenericClass && value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
+}
+
+@JsonSerializable()
+class Issue980ParentClass {
+  final List<Issue980GenericClass<int>> list;
+
+  Issue980ParentClass(this.list);
+
+  factory Issue980ParentClass.fromJson(Map<String, dynamic> json) =>
+      _$Issue980ParentClassFromJson(json);
+
+  Map<String, dynamic> toJson() => _$Issue980ParentClassToJson(this);
+
+  @override
+  bool operator ==(Object other) =>
+      other is Issue980ParentClass && deepEquals(list, other.list);
+
+  @override
+  int get hashCode => const DeepCollectionEquality().hash(list);
 }

--- a/json_serializable/test/generic_files/generic_class.g.dart
+++ b/json_serializable/test/generic_files/generic_class.g.dart
@@ -61,3 +61,17 @@ Map<String, dynamic> _$GenericClassWithConverterToJson<T extends num, S>(
       'listDuration': const _DurationListMillisecondConverter()
           .toJson(instance.listDuration),
     };
+
+Issue980ParentClass _$Issue980ParentClassFromJson(Map<String, dynamic> json) =>
+    Issue980ParentClass(
+      (json['list'] as List<dynamic>)
+          .map((e) =>
+              Issue980GenericClass<int>.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$Issue980ParentClassToJson(
+        Issue980ParentClass instance) =>
+    <String, dynamic>{
+      'list': instance.list,
+    };

--- a/json_serializable/test/generic_files/generic_test.dart
+++ b/json_serializable/test/generic_files/generic_test.dart
@@ -316,4 +316,14 @@ void main() {
       });
     });
   });
+
+  test('issue 980 regression test', () {
+    roundTripObject(
+      Issue980ParentClass([
+        Issue980GenericClass(45),
+        Issue980GenericClass(42),
+      ]),
+      (json) => Issue980ParentClass.fromJson(json),
+    );
+  });
 }

--- a/json_serializable/test/integration/json_test_common.dart
+++ b/json_serializable/test/integration/json_test_common.dart
@@ -4,7 +4,6 @@
 
 import 'dart:collection';
 
-import 'package:collection/collection.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 enum Category {
@@ -41,9 +40,6 @@ DateTime? dateTimeFromEpochUs(int? us) =>
     us == null ? null : DateTime.fromMicrosecondsSinceEpoch(us);
 
 int? dateTimeToEpochUs(DateTime? dateTime) => dateTime?.microsecondsSinceEpoch;
-
-bool deepEquals(dynamic a, dynamic b) =>
-    const DeepCollectionEquality().equals(a, b);
 
 class Platform {
   final String description;

--- a/json_serializable/test/integration/json_test_example.dart
+++ b/json_serializable/test/integration/json_test_example.dart
@@ -7,6 +7,7 @@ import 'dart:collection';
 
 import 'package:json_annotation/json_annotation.dart';
 
+import '../test_utils.dart';
 import 'json_test_common.dart';
 
 part 'json_test_example.g.dart';

--- a/json_serializable/test/integration/json_test_example.g.dart
+++ b/json_serializable/test/integration/json_test_example.g.dart
@@ -22,7 +22,7 @@ Person _$PersonFromJson(Map<String, dynamic> json) => Person(
           : Order.fromJson(json['order'] as Map<String, dynamic>)
       ..customOrders = json['customOrders'] == null
           ? null
-          : MyList.fromJson((json['customOrders'] as List<dynamic>)
+          : MyList<Order>.fromJson((json['customOrders'] as List<dynamic>)
               .map((e) => Order.fromJson(e as Map<String, dynamic>))
               .toList())
       ..houseMap = (json['houseMap'] as Map<String, dynamic>?)?.map(

--- a/json_serializable/test/integration/json_test_example.g_any_map.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.dart
@@ -7,6 +7,7 @@ import 'dart:collection';
 
 import 'package:json_annotation/json_annotation.dart';
 
+import '../test_utils.dart';
 import 'json_test_common.dart';
 
 part 'json_test_example.g_any_map.g.dart';

--- a/json_serializable/test/integration/json_test_example.g_any_map.g.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.g.dart
@@ -22,7 +22,7 @@ Person _$PersonFromJson(Map json) => Person(
           : Order.fromJson(Map<String, dynamic>.from(json['order'] as Map))
       ..customOrders = json['customOrders'] == null
           ? null
-          : MyList.fromJson((json['customOrders'] as List<dynamic>)
+          : MyList<Order>.fromJson((json['customOrders'] as List<dynamic>)
               .map((e) => Order.fromJson(Map<String, dynamic>.from(e as Map)))
               .toList())
       ..houseMap = (json['houseMap'] as Map?)?.map(

--- a/json_serializable/test/kitchen_sink/kitchen_sink_interface.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink_interface.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:collection/collection.dart';
-
+import '../test_utils.dart';
 import 'simple_object.dart';
 
 abstract class KitchenSinkFactory<K, V> {
@@ -123,24 +122,21 @@ bool sinkEquals(KitchenSink a, Object other) =>
     other is KitchenSink &&
     a.ctorValidatedNo42 == other.ctorValidatedNo42 &&
     a.dateTime == other.dateTime &&
-    _deepEquals(a.iterable, other.iterable) &&
-    _deepEquals(a.dynamicIterable, other.dynamicIterable) &&
+    deepEquals(a.iterable, other.iterable) &&
+    deepEquals(a.dynamicIterable, other.dynamicIterable) &&
     // objectIterable
     // intIterable
-    _deepEquals(a.dateTimeIterable, other.dateTimeIterable) &&
+    deepEquals(a.dateTimeIterable, other.dateTimeIterable) &&
     // list
     // dynamicList
     // objectList
     // intList
-    _deepEquals(a.dateTimeList, other.dateTimeList) &&
+    deepEquals(a.dateTimeList, other.dateTimeList) &&
     // map
     // stringStringMap
     // stringIntMap
-    _deepEquals(a.objectDateTimeMap, other.objectDateTimeMap) &&
-    _deepEquals(a.crazyComplex, other.crazyComplex) &&
+    deepEquals(a.objectDateTimeMap, other.objectDateTimeMap) &&
+    deepEquals(a.crazyComplex, other.crazyComplex) &&
     // val
     a.writeNotNull == other.writeNotNull &&
     a.string == other.string;
-
-bool _deepEquals(Object? a, Object? b) =>
-    const DeepCollectionEquality().equals(a, b);

--- a/json_serializable/test/src/_json_serializable_test_input.dart
+++ b/json_serializable/test/src/_json_serializable_test_input.dart
@@ -382,7 +382,8 @@ FieldWithFromJsonCtorAndTypeParams _$FieldWithFromJsonCtorAndTypeParamsFromJson(
     FieldWithFromJsonCtorAndTypeParams()
       ..customOrders = json['customOrders'] == null
           ? null
-          : MyList.fromJson((json['customOrders'] as List<dynamic>)
+          : MyList<GeneralTestClass2, int>.fromJson((json['customOrders']
+                  as List<dynamic>)
               .map((e) => GeneralTestClass2.fromJson(e as Map<String, dynamic>))
               .toList());
 ''')

--- a/json_serializable/test/test_utils.dart
+++ b/json_serializable/test/test_utils.dart
@@ -4,12 +4,16 @@
 
 import 'dart:convert';
 
+import 'package:collection/collection.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:test/test.dart';
 
 final throwsTypeError = throwsA(isTypeError);
 
 final isTypeError = isA<TypeError>();
+
+bool deepEquals(dynamic a, dynamic b) =>
+    const DeepCollectionEquality().equals(a, b);
 
 T roundTripObject<T>(T object, T Function(Map<String, dynamic> json) factory) {
   final data = loudEncode(object);


### PR DESCRIPTION
This fixes an edge case where the generic arguments could not be inferred.
Also DRY'd up some test helpers

Fixes https://github.com/google/json_serializable.dart/pull/980
Closes https://github.com/google/json_serializable.dart/pull/981
