### PR TITLE
Add @JsonEnum annotation

### DIFF
--- a/json_annotation/CHANGELOG.md
+++ b/json_annotation/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added `JsonSerializabel.constructor` field to allow specifying an alternative
   constructor to invoke when creating a `fromJson` helper.
+- Added `JsonEnum` for annotating `enum` types.  
 
 ## 4.1.0
 

--- a/json_annotation/lib/json_annotation.dart
+++ b/json_annotation/lib/json_annotation.dart
@@ -13,6 +13,7 @@ library json_annotation;
 export 'src/allowed_keys_helpers.dart';
 export 'src/checked_helpers.dart';
 export 'src/json_converter.dart';
+export 'src/json_enum.dart';
 export 'src/json_key.dart';
 export 'src/json_literal.dart';
 export 'src/json_serializable.dart';

--- a/json_annotation/lib/src/json_enum.dart
+++ b/json_annotation/lib/src/json_enum.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:meta/meta_meta.dart';
+
+/// When applied to `enum` definitions, causes the corresponding private
+//  `_$EnumNameEnumMap` and `_$enumDecode` helpers to be generated, even  if the
+//  `enum` is not referenced elsewhere in generated code.
+@Target({TargetKind.enumType})
+class JsonEnum {
+  const JsonEnum();
+}

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Added support for `JsonSerializabel.constructor` to allow specifying an 
   alternative constructor to invoke when creating a `fromJson` helper.
+- Support the new `@JsonEnum` annotation by generating the corresponding private
+  `_$EnumNameEnumMap` and `_$enumDecode` helpers, even  if the `enum` is not
+  referenced elsewhere in generated code.
 - Require `json_annotation` `'>=4.2.0 <4.3.0'`.
 
 ## 5.0.2

--- a/json_serializable/lib/json_serializable.dart
+++ b/json_serializable/lib/json_serializable.dart
@@ -2,5 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+export 'src/json_enum_generator.dart' show JsonEnumGenerator;
 export 'src/json_literal_generator.dart' show JsonLiteralGenerator;
 export 'src/json_serializable_generator.dart' show JsonSerializableGenerator;

--- a/json_serializable/lib/src/json_enum_generator.dart
+++ b/json_serializable/lib/src/json_enum_generator.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:build/build.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:source_gen/source_gen.dart';
+
+import 'type_helpers/enum_helper.dart';
+
+class JsonEnumGenerator extends GeneratorForAnnotation<JsonEnum> {
+  const JsonEnumGenerator();
+
+  @override
+  List<String> generateForAnnotatedElement(
+    Element element,
+    ConstantReader annotation,
+    BuildStep buildStep,
+  ) {
+    if (element is! ClassElement || !element.isEnum) {
+      throw InvalidGenerationSourceError(
+        '`@JsonEnum` can only be used on enum elements.',
+        element: element,
+      );
+    }
+
+    return [
+      enumDecodeHelper,
+      enumValueMapFromType(element.thisType)!,
+    ];
+  }
+}

--- a/json_serializable/lib/src/json_serializable_generator.dart
+++ b/json_serializable/lib/src/json_serializable_generator.dart
@@ -69,7 +69,7 @@ class JsonSerializableGenerator
       );
     }
 
-    if (element is! ClassElement) {
+    if (element is! ClassElement || element.isEnum) {
       throw InvalidGenerationSourceError(
         '`@JsonSerializable` can only be used on classes.',
         element: element,

--- a/json_serializable/lib/src/type_helpers/enum_helper.dart
+++ b/json_serializable/lib/src/type_helpers/enum_helper.dart
@@ -21,7 +21,7 @@ class EnumHelper extends TypeHelper<TypeHelperContextWithConfig> {
     String expression,
     TypeHelperContextWithConfig context,
   ) {
-    final memberContent = _enumValueMapFromType(targetType);
+    final memberContent = enumValueMapFromType(targetType);
 
     if (memberContent == null) {
       return null;
@@ -39,13 +39,13 @@ class EnumHelper extends TypeHelper<TypeHelperContextWithConfig> {
     TypeHelperContextWithConfig context,
     bool defaultProvided,
   ) {
-    final memberContent = _enumValueMapFromType(targetType);
+    final memberContent = enumValueMapFromType(targetType);
 
     if (memberContent == null) {
       return null;
     }
 
-    context.addMember(_enumDecodeHelper);
+    context.addMember(enumDecodeHelper);
 
     String functionName;
     if (targetType.isNullableType || defaultProvided) {
@@ -72,7 +72,7 @@ class EnumHelper extends TypeHelper<TypeHelperContextWithConfig> {
 String _constMapName(DartType targetType) =>
     '_\$${targetType.element!.name}EnumMap';
 
-String? _enumValueMapFromType(DartType targetType) {
+String? enumValueMapFromType(DartType targetType) {
   final enumMap = enumFieldsMap(targetType);
 
   if (enumMap == null) {
@@ -87,7 +87,7 @@ String? _enumValueMapFromType(DartType targetType) {
   return 'const ${_constMapName(targetType)} = {\n$items\n};';
 }
 
-const _enumDecodeHelper = r'''
+const enumDecodeHelper = r'''
 K _$enumDecode<K, V>(
   Map<K, V> enumValues,
   Object? source, {

--- a/json_serializable/lib/src/type_helpers/json_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_helper.dart
@@ -270,6 +270,9 @@ InterfaceType? _instantiate(
 }
 
 ClassConfig? _annotation(ClassConfig config, InterfaceType source) {
+  if (source.isEnum) {
+    return null;
+  }
   final annotations = const TypeChecker.fromRuntime(JsonSerializable)
       .annotationsOfExact(source.element, throwOnUnresolved: false)
       .toList();

--- a/json_serializable/test/integration/integration_test.dart
+++ b/json_serializable/test/integration/integration_test.dart
@@ -296,4 +296,8 @@ void main() {
 
     validateRoundTrip(value, (json) => PrivateConstructor.fromJson(json));
   });
+
+  test('enum helpers', () {
+    expect(standAloneEnumKeys, ['a', 'b', 'g', 'd']);
+  });
 }

--- a/json_serializable/test/integration/json_test_example.dart
+++ b/json_serializable/test/integration/json_test_example.dart
@@ -239,3 +239,17 @@ class PrivateConstructor {
   bool operator ==(Object other) =>
       other is PrivateConstructor && id == other.id && value == other.value;
 }
+
+@JsonEnum()
+enum StandAloneEnum {
+  @JsonValue('a')
+  alpha,
+  @JsonValue('b')
+  beta,
+  @JsonValue('g')
+  gamma,
+  @JsonValue('d')
+  delta,
+}
+
+Iterable<String> get standAloneEnumKeys => _$StandAloneEnumEnumMap.values;

--- a/json_serializable/test/integration/json_test_example.g.dart
+++ b/json_serializable/test/integration/json_test_example.g.dart
@@ -251,3 +251,10 @@ Map<String, dynamic> _$PrivateConstructorToJson(PrivateConstructor instance) =>
       'id': instance.id,
       'value': instance.value,
     };
+
+const _$StandAloneEnumEnumMap = {
+  StandAloneEnum.alpha: 'a',
+  StandAloneEnum.beta: 'b',
+  StandAloneEnum.gamma: 'g',
+  StandAloneEnum.delta: 'd',
+};

--- a/json_serializable/test/integration/json_test_example.g_any_map.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.dart
@@ -247,3 +247,17 @@ class PrivateConstructor {
   bool operator ==(Object other) =>
       other is PrivateConstructor && id == other.id && value == other.value;
 }
+
+@JsonEnum()
+enum StandAloneEnum {
+  @JsonValue('a')
+  alpha,
+  @JsonValue('b')
+  beta,
+  @JsonValue('g')
+  gamma,
+  @JsonValue('d')
+  delta,
+}
+
+Iterable<String> get standAloneEnumKeys => _$StandAloneEnumEnumMap.values;

--- a/json_serializable/test/integration/json_test_example.g_any_map.g.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.g.dart
@@ -249,3 +249,10 @@ Map<String, dynamic> _$PrivateConstructorToJson(PrivateConstructor instance) =>
       'id': instance.id,
       'value': instance.value,
     };
+
+const _$StandAloneEnumEnumMap = {
+  StandAloneEnum.alpha: 'a',
+  StandAloneEnum.beta: 'b',
+  StandAloneEnum.gamma: 'g',
+  StandAloneEnum.delta: 'd',
+};

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -24,6 +24,7 @@ Future<void> main() async {
 
 const _expectedAnnotatedTests = {
   'annotatedMethod',
+  'unsupportedEnum',
   'BadFromFuncReturnType',
   'BadNoArgs',
   'BadOneNamed',

--- a/json_serializable/test/src/_json_serializable_test_input.dart
+++ b/json_serializable/test/src/_json_serializable_test_input.dart
@@ -5,7 +5,6 @@
 import 'dart:collection';
 
 import 'package:json_annotation/json_annotation.dart';
-// ignore: import_of_legacy_library_into_null_safe
 import 'package:source_gen_test/annotations.dart';
 
 part 'checked_test_input.dart';
@@ -24,6 +23,10 @@ part 'unknown_enum_value_test_input.dart';
 @ShouldThrow('`@JsonSerializable` can only be used on classes.')
 @JsonSerializable() // ignore: invalid_annotation_target
 const theAnswer = 42;
+
+@ShouldThrow('`@JsonSerializable` can only be used on classes.')
+@JsonSerializable() // ignore: invalid_annotation_target
+enum unsupportedEnum { not, valid }
 
 @ShouldThrow('`@JsonSerializable` can only be used on classes.')
 @JsonSerializable() // ignore: invalid_annotation_target


### PR DESCRIPTION
Allows generating the associated helpers without requiring usage as a field
in a @JsonSerializable class

Fixes https://github.com/google/json_serializable.dart/issues/778
