### PR TITLE
[WIP] Automatically convert custom Maps key types

### DIFF
--- a/json_serializable/test/generic_files/generic_argument_factories.dart
+++ b/json_serializable/test/generic_files/generic_argument_factories.dart
@@ -50,3 +50,33 @@ class ConcreteClass {
 
   Map<String, dynamic> toJson() => _$ConcreteClassToJson(this);
 }
+
+class CustomMap<K, V> {
+  final Map<K, V> map;
+
+  CustomMap(this.map);
+
+  factory CustomMap.fromJson(
+    Map<String, dynamic> json,
+    K Function(String?) fromJsonK,
+    V Function(Object?) fromJsonV,
+  ) =>
+      CustomMap(json.map<K, V>(
+          (key, value) => MapEntry(fromJsonK(key), fromJsonV(value))));
+
+  Map<String?, dynamic> toJson(
+          String? Function(K) toJsonK, Object? Function(V) toJsonV) =>
+      map.map((key, value) => MapEntry(toJsonK(key), toJsonV(value)));
+}
+
+@JsonSerializable()
+class UseOfCustomMap {
+  final CustomMap<int, String> map;
+
+  UseOfCustomMap(this.map);
+
+  factory UseOfCustomMap.fromJson(Map<String, dynamic> json) =>
+      _$UseOfCustomMapFromJson(json);
+
+  Map<String, dynamic> toJson() => _$UseOfCustomMapToJson(this);
+}

--- a/json_serializable/test/generic_files/generic_argument_factories.g.dart
+++ b/json_serializable/test/generic_files/generic_argument_factories.g.dart
@@ -61,3 +61,17 @@ Map<String, dynamic> _$ConcreteClassToJson(ConcreteClass instance) =>
         (value) => value?.toString(),
       ),
     };
+
+UseOfCustomMap _$UseOfCustomMapFromJson(Map<String, dynamic> json) =>
+    UseOfCustomMap(
+      CustomMap<int, String>.fromJson(json['map'] as Map<String, dynamic>,
+          (value) => int.parse(value as String), (value) => value as String),
+    );
+
+Map<String, dynamic> _$UseOfCustomMapToJson(UseOfCustomMap instance) =>
+    <String, dynamic>{
+      'map': instance.map.toJson(
+        (value) => value.toString(),
+        (value) => value,
+      ),
+    };


### PR DESCRIPTION
Before
```dart
Map<int, String> // works
IMap<int, String> // does not work
```

Custom toJson / fromJson map types can now have keys serialized to strings. This expects the to/fromJson function to be of the form String Function(Object?) and Object? Function(String).

Resolves: #396

@kevmoo 