### PR TITLE
no error for dependency

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Support `JsonKey.readValue` to allow customized reading of values from source
   JSON map objects.
+- The check to make sure there is a correctly constrained dependency on
+  `package:json_annotation` is now a warning and doesn't fail the build.
 - Require `json_annotation` `'>=4.4.0 <4.5.0'`.
 
 ## 6.0.1

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -10,15 +10,15 @@
 
 ## 6.0.0
 
-- Added support for `JsonSerializable.constructor` to allow specifying an 
+- Added support for `JsonSerializable.constructor` to allow specifying an
   alternative constructor to invoke when creating a `fromJson` helper.
 - Support the new `@JsonEnum` annotation in `package:json_annotation`.
 - Support `JsonKey.nullForUndefinedEnumValue` as a value for
   `JsonKey.unknownEnumValue` when you want to use `null` as the unknown value.
 - Use the new `$enumDecodeNullable` and `$enumDecode` in `json_annotation'
-  instead of generating these for each library.
-  **NOTE**: This is a potential breaking change if any user code relies on
-  the previously generated private functions.
+  instead of generating these for each library. **NOTE**: This is a potential
+  breaking change if any user code relies on the previously generated private
+  functions.
 - The builder now checks to make sure there is a correctly constrained
   dependency on `package:json_annotation`.
 - Require Dart SDK `>=2.14.0`.
@@ -26,8 +26,8 @@
 
 ## 5.0.2
 
-- Include type arguments when invoking `fromJson` on custom types.
-  This fixes an edge case where the generic arguments could not be inferred.
+- Include type arguments when invoking `fromJson` on custom types. This fixes an
+  edge case where the generic arguments could not be inferred.
 
 ## 5.0.1
 
@@ -182,7 +182,7 @@
 
 ## 3.2.3
 
-- Bug fix for analyzer 0.38.5.
+- Fixed bug related to `package:analyzer` 0.38.5.
 
 ## 3.2.2
 
@@ -271,12 +271,12 @@ future feature work.
 ## 2.0.3
 
 - When invoking a `fromJson` constructor on a field type, generate a conversion
-  expression derived from the the constructor parameter type.
+  expression derived from the constructor parameter type.
 
 - Be more strict about the supported `List`, `Set`, or `Map` types. This may
-  causes errors to be raised in cases where invalid code was generated before.
-  It also allows implementations of these types to add a `fromJson` constructor
-  to support custom decoding.
+  cause errors to be raised in cases where invalid code was generated before. It
+  also allows implementations of these types to add a `fromJson` constructor to
+  support custom decoding.
 
 - Small change to the whitespace around converted maps to improve a very slow
   path when formatting generated code.
@@ -319,8 +319,7 @@ future feature work.
 
   - **BREAKING** `JsonSerializableGenerator` now exposes a `config` property of
     type `JsonSerializable` instead of individual properties for `checked`,
-    `anyMay`, etc. This will affect anyone creating or using this class via
-    code.
+    `anyMay`, etc. This will affect creating or using this class via code.
 
 - `type_helper.dart`
 
@@ -451,7 +450,7 @@ future feature work.
 - Added `JsonKey.disallowNullValue`.
 
   - When `true`, generated code throws a `DisallowedNullValueException` if the
-    corresponding keys exist in in the JSON map, but it's value is null.
+    corresponding keys exist in the JSON map, but its value is `null`.
   - Will be captured and wrapped in a `CheckedFromJsonException` if `checked` is
     enabled in `json_serializable`.
 
@@ -641,7 +640,7 @@ future feature work.
 - Moved the annotations in `annotations.dart` to `package:json_annotations`.
 
   - Allows package authors to release code that has the corresponding
-    annotations without requiring package users to inherit all of the transitive
+    annotations without requiring package users to inherit all the transitive
     dependencies.
 
 - Deprecated `annotations.dart`.
@@ -687,7 +686,7 @@ future feature work.
     and related helpers which allow custom generation for specific types.
 
 - **BREAKING** Generation fails for types that are not a JSON primitive or that
-  do not explicitly supports JSON serialization.
+  do not explicitly support JSON serialization.
 
 - **BREAKING** `TypeHelper`:
 

--- a/json_serializable/lib/src/check_dependencies.dart
+++ b/json_serializable/lib/src/check_dependencies.dart
@@ -51,7 +51,7 @@ Future<void> _validatePubspec(bool production, BuildStep buildStep) async {
 
   if (errorMessage == null) return;
 
-  throw BadPackageDependencyError(errorMessage);
+  log.warning(errorMessage);
 }
 
 String? _checkAnnotationConstraint(
@@ -123,14 +123,4 @@ class _OncePerBuild {
       await _callback(state, buildStep);
     }
   }
-}
-
-/// Thrown when a pubspec dependency is missing or incorrectly specified.
-class BadPackageDependencyError extends Error {
-  final String message;
-
-  BadPackageDependencyError(this.message);
-
-  @override
-  String toString() => message;
 }

--- a/json_serializable/test/annotation_version_test.dart
+++ b/json_serializable/test/annotation_version_test.dart
@@ -172,10 +172,8 @@ class SomeClass{}
   }
 
   expect(lines.toString(), contains('''
-[SEVERE] json_serializable:json_serializable on $sourceDirectory/sample.dart:
+[WARNING] json_serializable:json_serializable on $sourceDirectory/sample.dart:
+$message'''));
 
-$message
-'''));
-
-  await proc.shouldExit(1);
+  await proc.shouldExit(0);
 }


### PR DESCRIPTION
- Cleanup changelog
- Just warn (don't fail) when the json_annotation constraint looks wrong
