### PR TITLE
Add custom instance parameter to FromJson method

### DIFF
--- a/json_serializable/lib/src/decode_helper.dart
+++ b/json_serializable/lib/src/decode_helper.dart
@@ -32,7 +32,7 @@ abstract class DecodeHelper implements HelperCore {
     final mapType = config.anyMap ? 'Map' : 'Map<String, dynamic>';
     buffer.write('$targetClassReference '
         '${prefix}FromJson${genericClassArgumentsImpl(true)}'
-        '($mapType json');
+        '($mapType json, $targetClassReference? existingInstance');
 
     if (config.genericArgumentFactories) {
       for (var arg in element.typeParameters) {
@@ -311,7 +311,7 @@ _ConstructorData _writeConstructorInvocation(
 
   final buffer = StringBuffer()
     ..write(
-      '$className'
+      '(existingInstance != null ? existingInstance : $className'
       '${genericClassArguments(classElement, false)}'
       '$constructorExtra(',
     );
@@ -334,7 +334,7 @@ _ConstructorData _writeConstructorInvocation(
       }));
   }
 
-  buffer.write(')');
+  buffer.write('))');
 
   usedCtorParamsAndFields.addAll(remainingFieldsForInvocationBody);
 


### PR DESCRIPTION
This PR will allow the _$CLASSFromJson method to optionally receive an instance of the object at a second parameter.

Whenever You already have an instance of a given class you can use populate the properties of this instance instead of creating a new one and replacing multiple previous pointers to the old instance.

This way you can have a method like this, on instance level.
```dart

void fromJson(Map<String, dynamic> json) => _$CLASSFromJson(json, this);

```

