### PR TITLE
adding support for custom instance on fromjson

### DIFF
--- a/json_serializable/lib/src/decode_helper.dart
+++ b/json_serializable/lib/src/decode_helper.dart
@@ -32,7 +32,7 @@ abstract class DecodeHelper implements HelperCore {
     final mapType = config.anyMap ? 'Map' : 'Map<String, dynamic>';
     buffer.write('$targetClassReference '
         '${prefix}FromJson${genericClassArgumentsImpl(true)}'
-        '($mapType json, $targetClassReference? existingInstance');
+        '($mapType json, { $targetClassReference? existingInstance }');
 
     if (config.genericArgumentFactories) {
       for (var arg in element.typeParameters) {
@@ -311,7 +311,7 @@ _ConstructorData _writeConstructorInvocation(
 
   final buffer = StringBuffer()
     ..write(
-      '(existingInstance != null ? existingInstance : $className'
+      '(existingInstance ?? $className'
       '${genericClassArguments(classElement, false)}'
       '$constructorExtra(',
     );

--- a/json_serializable/lib/src/decode_helper.dart
+++ b/json_serializable/lib/src/decode_helper.dart
@@ -32,7 +32,7 @@ abstract class DecodeHelper implements HelperCore {
     final mapType = config.anyMap ? 'Map' : 'Map<String, dynamic>';
     buffer.write('$targetClassReference '
         '${prefix}FromJson${genericClassArgumentsImpl(true)}'
-        '($mapType json');
+        '($mapType json, $targetClassReference? existingInstance');
 
     if (config.genericArgumentFactories) {
       for (var arg in element.typeParameters) {
@@ -311,7 +311,7 @@ _ConstructorData _writeConstructorInvocation(
 
   final buffer = StringBuffer()
     ..write(
-      '$className'
+      '(existingInstance != null ? existingInstance : $className'
       '${genericClassArguments(classElement, false)}'
       '$constructorExtra(',
     );
@@ -334,7 +334,7 @@ _ConstructorData _writeConstructorInvocation(
       }));
   }
 
-  buffer.write(')');
+  buffer.write('))');
 
   usedCtorParamsAndFields.addAll(remainingFieldsForInvocationBody);
 

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 6.1.4
+version: 6.1.41
 description: >-
   Automatically generate code for converting to and from JSON by annotating
   Dart classes.

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,22 +1,22 @@
 name: json_serializable
-version: 6.1.3
+version: 6.1.4
 description: >-
   Automatically generate code for converting to and from JSON by annotating
   Dart classes.
 repository: https://github.com/google/json_serializable.dart/tree/master/json_serializable
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
-  analyzer: '>=2.0.0 <4.0.0'
+  analyzer: ">=2.0.0 <4.0.0"
   async: ^2.8.0
   build: ^2.0.0
-  build_config: '>=0.4.4 <2.0.0'
+  build_config: ">=0.4.4 <2.0.0"
   collection: ^1.14.0
 
   # Use a tight version constraint to ensure that a constraint on
   # `json_annotation` properly constrains all features it provides.
-  json_annotation: '>=4.4.0 <4.5.0'
+  json_annotation: ">=4.4.0 <4.5.0"
   meta: ^1.3.0
   path: ^1.8.0
   pub_semver: ^2.0.0


### PR DESCRIPTION
This PR will allow the _$CLASSFromJson method to optionally receive an instance of the object at a second parameter.

Whenever You already have an instance of a given class you can use populate the properties of this instance instead of creating a new one and replacing multiple previous pointers to the old instance.

This way you can have a method like this, on instance level.
```dart

void fromJson(Map<String, dynamic> json) => _$CLASSFromJson(json, existingInstance: this);

```

