### PR TITLE
docs: fix typo in README

### DIFF
--- a/json_serializable/README.md
+++ b/json_serializable/README.md
@@ -17,8 +17,8 @@ in [package:json_annotation].
 
 ## Setup
 
-To configure your project for the latest released version of,
-`json_serializable` see the [example].
+To configure your project for the latest released version of
+`json_serializable`, see the [example].
 
 ## Example
 


### PR DESCRIPTION
Comma typo fix in the README.

Replaces the sentence:

_To configure your project for the latest released version of,
`json_serializable` see the [example]._ 

with

_To configure your project for the latest released version of
`json_serializable`, see the [example]._