### PR TITLE
Add support for screaming snake case #1032

### DIFF
--- a/checked_yaml/pubspec.yaml
+++ b/checked_yaml/pubspec.yaml
@@ -24,3 +24,5 @@ dev_dependencies:
 dependency_overrides:
   json_annotation:
     path: ../json_annotation
+  json_serializable:
+    path: ../json_serializable

--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -22,7 +22,11 @@ enum FieldRename {
   snake,
 
   /// Encodes a field named `pascalCase` with a JSON key `PascalCase`.
-  pascal
+  pascal,
+
+  /// Encodes a field named `screamingSnakeCase` with a JSON key
+  /// `SCREAMING_SNAKE_CASE`
+  screamingSnake,
 }
 
 /// An annotation used to specify a class to generate code for.

--- a/json_annotation/lib/src/json_serializable.g.dart
+++ b/json_annotation/lib/src/json_serializable.g.dart
@@ -117,4 +117,5 @@ const _$FieldRenameEnumMap = {
   FieldRename.kebab: 'kebab',
   FieldRename.snake: 'snake',
   FieldRename.pascal: 'pascal',
+  FieldRename.screamingSnake: 'screamingSnake',
 };

--- a/json_serializable/lib/src/type_helpers/config_types.dart
+++ b/json_serializable/lib/src/type_helpers/config_types.dart
@@ -117,6 +117,7 @@ const _$FieldRenameEnumMap = {
   FieldRename.kebab: 'kebab',
   FieldRename.snake: 'snake',
   FieldRename.pascal: 'pascal',
+  FieldRename.screamingSnake: 'screamingSnake',
 };
 
 // #CHANGE WHEN UPDATING json_annotation

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -178,6 +178,8 @@ String encodedFieldName(
       return declaredName;
     case FieldRename.snake:
       return declaredName.snake;
+    case FieldRename.screamingSnake:
+      return declaredName.snake.toUpperCase();
     case FieldRename.kebab:
       return declaredName.kebab;
     case FieldRename.pascal:

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -36,3 +36,7 @@ dev_dependencies:
   test_descriptor: ^2.0.0
   test_process: ^2.0.0
   yaml: ^3.0.0
+
+dependency_overrides:
+  json_annotation:
+   path: ../json_annotation

--- a/json_serializable/test/config_test.dart
+++ b/json_serializable/test/config_test.dart
@@ -120,7 +120,7 @@ void main() {
           case 'field_rename':
             lastLine =
                 '`42` is not one of the supported values: none, kebab, snake, '
-                'pascal';
+                'pascal, screamingSnake';
             break;
           case 'constructor':
             lastLine = "type 'int' is not a subtype of type 'String?' in type "

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -58,6 +58,7 @@ const _expectedAnnotatedTests = {
   'FieldNamerKebab',
   'FieldNamerNone',
   'FieldNamerPascal',
+  'FieldNamerScreamingSnake',
   'FieldNamerSnake',
   'FieldWithFromJsonCtorAndTypeParams',
   'FinalFields',

--- a/json_serializable/test/src/field_namer_input.dart
+++ b/json_serializable/test/src/field_namer_input.dart
@@ -59,3 +59,19 @@ class FieldNamerSnake {
   @JsonKey(name: 'NAME_OVERRIDE')
   late String nameOverride;
 }
+
+@ShouldGenerate(r'''
+Map<String, dynamic> _$FieldNamerScreamingSnakeToJson(
+        FieldNamerScreamingSnake instance) =>
+    <String, dynamic>{
+      'THE_FIELD': instance.theField,
+      'nameOverride': instance.nameOverride,
+    };
+''')
+@JsonSerializable(fieldRename: FieldRename.screamingSnake, createFactory: false)
+class FieldNamerScreamingSnake {
+  late String theField;
+
+  @JsonKey(name: 'nameOverride')
+  late String nameOverride;
+}


### PR DESCRIPTION
Adds support for `SCREAMING_SNAKE_CASE` field renaming ( #1032 ).

Happy to call it whatever - have also seen it called "macro case", "constant case" or "upper snake case" but screaming snake is what is used in the [wikipedia article on snake case](https://en.wikipedia.org/wiki/Snake_case).