### PR TITLE
Updated depcreated analyzer members to new ones

### DIFF
--- a/json_serializable/lib/src/enum_utils.dart
+++ b/json_serializable/lib/src/enum_utils.dart
@@ -12,13 +12,13 @@ import 'json_literal_generator.dart';
 import 'utils.dart';
 
 String constMapName(DartType targetType) =>
-    '_\$${targetType.element!.name}EnumMap';
+    '_\$${targetType.element2!.name}EnumMap';
 
 String? enumValueMapFromType(
   DartType targetType, {
   bool nullWithNoAnnotation = false,
 }) {
-  final annotation = _jsonEnumChecker.firstAnnotationOf(targetType.element!);
+  final annotation = _jsonEnumChecker.firstAnnotationOf(targetType.element2!);
   final jsonEnum = _fromAnnotation(annotation);
 
   final enumFields = iterateEnumFields(targetType);
@@ -59,7 +59,7 @@ String? enumValueMapFromType(
       Map<FieldElement, dynamic>.fromEntries(enumFields.map(generateEntry));
 
   final items = enumMap.entries
-      .map((e) => '  ${targetType.element!.name}.${e.key.name}: '
+      .map((e) => '  ${targetType.element2!.name}.${e.key.name}: '
           '${jsonLiteralAsDart(e.value)},')
       .join();
 

--- a/json_serializable/lib/src/field_helpers.dart
+++ b/json_serializable/lib/src/field_helpers.dart
@@ -37,20 +37,20 @@ class _FieldSet implements Comparable<_FieldSet> {
 
   static int _sortByLocation(FieldElement a, FieldElement b) {
     final checkerA =
-        TypeChecker.fromStatic((a.enclosingElement2 as ClassElement).thisType);
+        TypeChecker.fromStatic((a.enclosingElement3 as ClassElement).thisType);
 
-    if (!checkerA.isExactly(b.enclosingElement2)) {
+    if (!checkerA.isExactly(b.enclosingElement3)) {
       // in this case, you want to prioritize the enclosingElement that is more
       // "super".
 
-      if (checkerA.isAssignableFrom(b.enclosingElement2)) {
+      if (checkerA.isAssignableFrom(b.enclosingElement3)) {
         return -1;
       }
 
       final checkerB = TypeChecker.fromStatic(
-          (b.enclosingElement2 as ClassElement).thisType);
+          (b.enclosingElement3 as ClassElement).thisType);
 
-      if (checkerB.isAssignableFrom(a.enclosingElement2)) {
+      if (checkerB.isAssignableFrom(a.enclosingElement3)) {
         return 1;
       }
     }
@@ -82,7 +82,7 @@ Iterable<FieldElement> createSortedFieldSet(ClassElement element) {
 
   for (final v in manager.getInheritedConcreteMap2(element).values) {
     assert(v is! FieldElement);
-    if (_dartCoreObjectChecker.isExactly(v.enclosingElement2)) {
+    if (_dartCoreObjectChecker.isExactly(v.enclosingElement3)) {
       continue;
     }
 

--- a/json_serializable/lib/src/helper_core.dart
+++ b/json_serializable/lib/src/helper_core.dart
@@ -78,7 +78,7 @@ $converterOrKeyInstructions
     message = '$message because of type `${typeToCode(error.type)}`';
   } else {
     todo = '''
-To support the type `${error.type.element!.name}` you can:
+To support the type `${error.type.element2!.name}` you can:
 $converterOrKeyInstructions''';
   }
 

--- a/json_serializable/lib/src/json_enum_generator.dart
+++ b/json_serializable/lib/src/json_enum_generator.dart
@@ -18,7 +18,7 @@ class JsonEnumGenerator extends GeneratorForAnnotation<JsonEnum> {
     ConstantReader annotation,
     BuildStep buildStep,
   ) {
-    if (element is! ClassElement || !element.isEnum) {
+    if (element is! ClassElement || element is! EnumElement) {
       throw InvalidGenerationSourceError(
         '`@JsonEnum` can only be used on enum elements.',
         element: element,

--- a/json_serializable/lib/src/json_key_utils.dart
+++ b/json_serializable/lib/src/json_key_utils.dart
@@ -61,7 +61,7 @@ KeyConfig _from(FieldElement element, ClassConfig classAnnotation) {
       // TODO: Support calling function for the default value?
       badType = 'Function';
     } else if (!reader.isLiteral) {
-      badType = dartObject.type!.element!.name;
+      badType = dartObject.type!.element2!.name;
     }
 
     if (badType != null) {
@@ -173,7 +173,7 @@ KeyConfig _from(FieldElement element, ClassConfig classAnnotation) {
       final enumValueName = enumValueForDartObject<String>(
           annotationValue.objectValue, enumValueNames, (n) => n);
 
-      return '${annotationType.element!.name}'
+      return '${annotationType.element2!.name}'
           '.$enumValueName';
     } else {
       final defaultValueLiteral = annotationValue.isNull
@@ -280,7 +280,7 @@ bool _includeIfNull(
 bool _interfaceTypesEqual(DartType a, DartType b) {
   if (a is InterfaceType && b is InterfaceType) {
     // Handle nullability case. Pretty sure this is fine for enums.
-    return a.element == b.element;
+    return a.element2 == b.element2;
   }
   return a == b;
 }

--- a/json_serializable/lib/src/json_serializable_generator.dart
+++ b/json_serializable/lib/src/json_serializable_generator.dart
@@ -69,7 +69,7 @@ class JsonSerializableGenerator
       );
     }
 
-    if (element is! ClassElement || element.isEnum) {
+    if (element is! ClassElement || element is EnumElement) {
       throw InvalidGenerationSourceError(
         '`@JsonSerializable` can only be used on classes.',
         element: element,

--- a/json_serializable/lib/src/type_helpers/json_converter_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_converter_helper.dart
@@ -199,7 +199,7 @@ _JsonConvertData? _typeConverterFrom(
 
   final annotationElement = match.elementAnnotation?.element;
   if (annotationElement is PropertyAccessorElement) {
-    final enclosing = annotationElement.enclosingElement2;
+    final enclosing = annotationElement.enclosingElement3;
 
     var accessString = annotationElement.name;
 
@@ -226,7 +226,7 @@ _JsonConvertData? _typeConverterFrom(
 
   if (match.genericTypeArg != null) {
     return _JsonConvertData.genericClass(
-      match.annotation.type!.element!.name!,
+      match.annotation.type!.element2!.name!,
       match.genericTypeArg!,
       reviver.accessor,
       match.jsonType,
@@ -235,7 +235,7 @@ _JsonConvertData? _typeConverterFrom(
   }
 
   return _JsonConvertData.className(
-    match.annotation.type!.element!.name!,
+    match.annotation.type!.element2!.name!,
     reviver.accessor,
     match.jsonType,
     match.fieldType,
@@ -263,18 +263,18 @@ _ConverterMatch? _compatibleMatch(
   ElementAnnotation? annotation,
   DartObject constantValue,
 ) {
-  final converterClassElement = constantValue.type!.element as ClassElement;
+  final converterClassElement = constantValue.type!.element2 as ClassElement;
 
   final jsonConverterSuper =
       converterClassElement.allSupertypes.singleWhereOrNull(
-    (e) => _jsonConverterChecker.isExactly(e.element),
+    (e) => _jsonConverterChecker.isExactly(e.element2),
   );
 
   if (jsonConverterSuper == null) {
     return null;
   }
 
-  assert(jsonConverterSuper.element.typeParameters.length == 2);
+  assert(jsonConverterSuper.element2.typeParameters.length == 2);
   assert(jsonConverterSuper.typeArguments.length == 2);
 
   final fieldType = jsonConverterSuper.typeArguments[0];
@@ -305,7 +305,7 @@ _ConverterMatch? _compatibleMatch(
       annotation,
       constantValue,
       jsonConverterSuper.typeArguments[1],
-      '${targetType.element.name}${targetType.isNullableType ? '?' : ''}',
+      '${targetType.element2.name}${targetType.isNullableType ? '?' : ''}',
       fieldType,
     );
   }

--- a/json_serializable/lib/src/type_helpers/json_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_helper.dart
@@ -76,7 +76,7 @@ class JsonHelper extends TypeHelper<TypeHelperContextWithConfig> {
       return null;
     }
 
-    final classElement = targetType.element;
+    final classElement = targetType.element2;
 
     final fromJsonCtor = classElement.constructors
         .singleWhereOrNull((ce) => ce.name == 'fromJson');
@@ -152,7 +152,7 @@ List<String> _helperParams(
 
   for (var helperArg in rest) {
     final typeParamIndex =
-        type.element.typeParameters.indexOf(helperArg.element);
+        type.element2.typeParameters.indexOf(helperArg.element2);
 
     // TODO: throw here if `typeParamIndex` is -1 ?
     final typeArg = type.typeArguments[typeParamIndex];
@@ -174,7 +174,7 @@ TypeParameterType _decodeHelper(
       type.normalParameterTypes.length == 1) {
     final funcReturnType = type.returnType;
 
-    if (param.name == fromJsonForName(funcReturnType.element!.name!)) {
+    if (param.name == fromJsonForName(funcReturnType.element2!.name!)) {
       final funcParamType = type.normalParameterTypes.single;
 
       if ((funcParamType.isDartCoreObject && funcParamType.isNullableType) ||
@@ -205,7 +205,7 @@ TypeParameterType _encodeHelper(
       type.normalParameterTypes.length == 1) {
     final funcParamType = type.normalParameterTypes.single;
 
-    if (param.name == toJsonForName(funcParamType.element!.name!)) {
+    if (param.name == toJsonForName(funcParamType.element2!.name!)) {
       if (funcParamType is TypeParameterType) {
         return funcParamType;
       }
@@ -245,7 +245,7 @@ InterfaceType? _instantiate(
   InterfaceType classType,
 ) {
   final argTypes = ctorParamType.typeArguments.map((arg) {
-    final typeParamIndex = classType.element.typeParameters.indexWhere(
+    final typeParamIndex = classType.element2.typeParameters.indexWhere(
         // TODO: not 100% sure `nullabilitySuffix` is right
         (e) => e.instantiate(nullabilitySuffix: arg.nullabilitySuffix) == arg);
     if (typeParamIndex >= 0) {
@@ -261,7 +261,7 @@ InterfaceType? _instantiate(
     return null;
   }
 
-  return ctorParamType.element.instantiate(
+  return ctorParamType.element2.instantiate(
     typeArguments: argTypes.cast<DartType>(),
     // TODO: not 100% sure nullabilitySuffix is right... Works for now
     nullabilitySuffix: NullabilitySuffix.none,
@@ -273,7 +273,7 @@ ClassConfig? _annotation(ClassConfig config, InterfaceType source) {
     return null;
   }
   final annotations = const TypeChecker.fromRuntime(JsonSerializable)
-      .annotationsOfExact(source.element, throwOnUnresolved: false)
+      .annotationsOfExact(source.element2, throwOnUnresolved: false)
       .toList();
 
   if (annotations.isEmpty) {
@@ -283,7 +283,7 @@ ClassConfig? _annotation(ClassConfig config, InterfaceType source) {
   return mergeConfig(
     config,
     ConstantReader(annotations.single),
-    classElement: source.element,
+    classElement: source.element2 as ClassElement,
   );
 }
 

--- a/json_serializable/lib/src/type_helpers/json_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_helper.dart
@@ -280,6 +280,10 @@ ClassConfig? _annotation(ClassConfig config, InterfaceType source) {
     return null;
   }
 
+  if (source.element2 is! ClassElement) {
+    return null;
+  }
+
   return mergeConfig(
     config,
     ConstantReader(annotations.single),

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -160,15 +160,16 @@ ConstructorElement constructorByName(ClassElement classElement, String name) {
 ///
 /// Otherwise, `null`.
 Iterable<FieldElement>? iterateEnumFields(DartType targetType) {
-  if (targetType is InterfaceType && targetType.element.isEnum) {
-    return targetType.element.fields.where((element) => element.isEnumConstant);
+  if (targetType is InterfaceType && targetType.element2 is EnumElement) {
+    return targetType.element2.fields
+        .where((element) => element.isEnumConstant);
   }
   return null;
 }
 
 extension DartTypeExtension on DartType {
   DartType promoteNonNullable() =>
-      element?.library?.typeSystem.promoteToNonNull(this) ?? this;
+      element2?.library?.typeSystem.promoteToNonNull(this) ?? this;
 }
 
 String ifNullOrElse(String test, String ifNull, String ifNotNull) =>
@@ -206,7 +207,7 @@ String typeToCode(
     return 'dynamic';
   } else if (type is InterfaceType) {
     return [
-      type.element.name,
+      type.element2.name,
       if (type.typeArguments.isNotEmpty)
         '<${type.typeArguments.map(typeToCode).join(', ')}>',
       (type.isNullableType || forceNullable) ? '?' : '',
@@ -228,7 +229,7 @@ extension ExecutableElementExtension on ExecutableElement {
     }
 
     if (this is MethodElement) {
-      return '${enclosingElement2.name}.$name';
+      return '${enclosingElement3.name}.$name';
     }
 
     throw UnsupportedError(


### PR DESCRIPTION
This PR is just a fix to 38 deprecation warning from the analyzer package:

i.e. the following:
- `element` -> `element2`
- `enclosingElement2` -> `enclosingElement3`
- `element.isEnum` -> `element is EnumElement`

