### PR TITLE
Fix JsonConverter docs example

### DIFF
--- a/json_annotation/lib/src/json_converter.dart
+++ b/json_annotation/lib/src/json_converter.dart
@@ -36,7 +36,7 @@
 /// Or finally, passed to the annotation:
 ///
 ///```dart
-/// @JsonSerializable(converters: [MyConverter()])
+/// @JsonSerializable(converters: [MyJsonConverter()])
 /// class Example {}
 /// ```
 abstract class JsonConverter<T, S> {

--- a/json_annotation/lib/src/json_converter.dart
+++ b/json_annotation/lib/src/json_converter.dart
@@ -13,7 +13,7 @@
 /// [JsonConverter]s can be placed either on the class:
 ///
 /// ```dart
-/// class MyConverter extends JsonConverter<Value, JSON> {
+/// class MyJsonConverter extends JsonConverter<Value, JSON> {
 ///   // TODO
 /// }
 ///


### PR DESCRIPTION
The docs have an example where the Converter class name differs from when it's used as an annotation.

Closes #1194.