### PR TITLE
Fix a bug when annotated classes also use mixins

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 6.4.1-dev
+## 6.4.1
 
+- Fixed a bug when an `@JsonSerializable` class uses a mixin with fields.
 - Added more documentation `@JsonEnum`.
 
 ## 6.4.0

--- a/json_serializable/lib/src/field_helpers.dart
+++ b/json_serializable/lib/src/field_helpers.dart
@@ -36,8 +36,9 @@ class _FieldSet implements Comparable<_FieldSet> {
   int compareTo(_FieldSet other) => _sortByLocation(sortField, other.sortField);
 
   static int _sortByLocation(FieldElement a, FieldElement b) {
-    final checkerA =
-        TypeChecker.fromStatic((a.enclosingElement3 as ClassElement).thisType);
+    final checkerA = TypeChecker.fromStatic(
+      (a.enclosingElement3 as InterfaceElement).thisType,
+    );
 
     if (!checkerA.isExactly(b.enclosingElement3)) {
       // in this case, you want to prioritize the enclosingElement that is more

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 6.4.1-dev
+version: 6.4.1
 description: >-
   Automatically generate code for converting to and from JSON by annotating
   Dart classes.

--- a/json_serializable/test/integration/json_test_example.dart
+++ b/json_serializable/test/integration/json_test_example.dart
@@ -251,5 +251,9 @@ mixin RegressionTestIssue1210Mixin {
 class RegressionTestIssue1210 with RegressionTestIssue1210Mixin {
   const RegressionTestIssue1210(this.field);
 
+  factory RegressionTestIssue1210.fromJson(Map<String, dynamic> json) =>
+      _$RegressionTestIssue1210FromJson(json);
   final String field;
+
+  Map<String, dynamic> toJson() => _$RegressionTestIssue1210ToJson(this);
 }

--- a/json_serializable/test/integration/json_test_example.dart
+++ b/json_serializable/test/integration/json_test_example.dart
@@ -239,3 +239,17 @@ class PrivateConstructor {
   bool operator ==(Object other) =>
       other is PrivateConstructor && id == other.id && value == other.value;
 }
+
+mixin RegressionTestIssue1210Mixin {
+  bool? get someProperty => null;
+
+  @override
+  int get hashCode => identityHashCode(this);
+}
+
+@JsonSerializable()
+class RegressionTestIssue1210 with RegressionTestIssue1210Mixin {
+  const RegressionTestIssue1210(this.field);
+
+  final String field;
+}

--- a/json_serializable/test/integration/json_test_example.g.dart
+++ b/json_serializable/test/integration/json_test_example.g.dart
@@ -213,3 +213,15 @@ Map<String, dynamic> _$PrivateConstructorToJson(PrivateConstructor instance) =>
       'id': instance.id,
       'value': instance.value,
     };
+
+RegressionTestIssue1210 _$RegressionTestIssue1210FromJson(
+        Map<String, dynamic> json) =>
+    RegressionTestIssue1210(
+      json['field'] as String,
+    );
+
+Map<String, dynamic> _$RegressionTestIssue1210ToJson(
+        RegressionTestIssue1210 instance) =>
+    <String, dynamic>{
+      'field': instance.field,
+    };

--- a/json_serializable/test/integration/json_test_example.g_any_map.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.dart
@@ -261,5 +261,9 @@ mixin RegressionTestIssue1210Mixin {
 class RegressionTestIssue1210 with RegressionTestIssue1210Mixin {
   const RegressionTestIssue1210(this.field);
 
+  factory RegressionTestIssue1210.fromJson(Map<String, dynamic> json) =>
+      _$RegressionTestIssue1210FromJson(json);
   final String field;
+
+  Map<String, dynamic> toJson() => _$RegressionTestIssue1210ToJson(this);
 }

--- a/json_serializable/test/integration/json_test_example.g_any_map.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.dart
@@ -247,3 +247,19 @@ class PrivateConstructor {
   bool operator ==(Object other) =>
       other is PrivateConstructor && id == other.id && value == other.value;
 }
+
+mixin RegressionTestIssue1210Mixin {
+  bool? get someProperty => null;
+
+  @override
+  int get hashCode => identityHashCode(this);
+}
+
+@JsonSerializable(
+  anyMap: true,
+)
+class RegressionTestIssue1210 with RegressionTestIssue1210Mixin {
+  const RegressionTestIssue1210(this.field);
+
+  final String field;
+}

--- a/json_serializable/test/integration/json_test_example.g_any_map.g.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.g.dart
@@ -211,3 +211,14 @@ Map<String, dynamic> _$PrivateConstructorToJson(PrivateConstructor instance) =>
       'id': instance.id,
       'value': instance.value,
     };
+
+RegressionTestIssue1210 _$RegressionTestIssue1210FromJson(Map json) =>
+    RegressionTestIssue1210(
+      json['field'] as String,
+    );
+
+Map<String, dynamic> _$RegressionTestIssue1210ToJson(
+        RegressionTestIssue1210 instance) =>
+    <String, dynamic>{
+      'field': instance.field,
+    };


### PR DESCRIPTION
Swapped a cast to ClassElement to less specific InterfaceElement

Fixes https://github.com/google/json_serializable.dart/issues/1210

Prepare to release v6.4.1
