### PR TITLE
Improve encoding of values to handle null cases

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.5.2
+
+- Better handling of `null` when encoding `enum` values or values with
+  conversions.
+
 ## 6.5.1
 
 - Fixed `BigInt`, `DateTime`, and `Uri` support for `JsonKey.defaultValue` with

--- a/json_serializable/lib/src/encoder_helper.dart
+++ b/json_serializable/lib/src/encoder_helper.dart
@@ -4,10 +4,10 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
-import 'package:json_annotation/json_annotation.dart';
 import 'package:source_helper/source_helper.dart';
 
 import 'constants.dart';
+import 'enum_utils.dart';
 import 'helper_core.dart';
 import 'type_helpers/generic_factory_helper.dart';
 import 'type_helpers/json_converter_helper.dart';
@@ -163,19 +163,32 @@ abstract class EncodeHelper implements HelperCore {
   bool _writeJsonValueNaive(FieldElement field) {
     final jsonKey = jsonKeyFor(field);
 
-    return jsonKey.includeIfNull ||
-        (!field.type.isNullableType && !_fieldHasCustomEncoder(field));
-  }
+    if (jsonKey.includeIfNull) {
+      return true;
+    }
 
-  /// Returns `true` if [field] has a user-defined encoder.
-  ///
-  /// This can be either a `toJson` function in [JsonKey] or a [JsonConverter]
-  /// annotation.
-  bool _fieldHasCustomEncoder(FieldElement field) {
     final helperContext = getHelperContext(field);
-    return helperContext.serializeConvertData != null ||
-        const JsonConverterHelper()
-                .serialize(field.type, 'test', helperContext) !=
-            null;
+
+    final serializeConvertData = helperContext.serializeConvertData;
+    if (serializeConvertData != null) {
+      return !serializeConvertData.returnType.isNullableType;
+    }
+
+    final nullableEncodeConverter =
+        hasConverterNullEncode(field.type, helperContext);
+
+    if (nullableEncodeConverter != null) {
+      return !nullableEncodeConverter;
+    }
+
+    // We can consider enums as kinda like having custom converters
+    // same rules apply. If `null` is in the set of encoded values, we
+    // should not write naive
+    final enumWithNullValue = enumFieldWithNullInEncodeMap(field.type);
+    if (enumWithNullValue != null) {
+      return !enumWithNullValue;
+    }
+
+    return !field.type.isNullableType;
   }
 }

--- a/json_serializable/lib/src/enum_utils.dart
+++ b/json_serializable/lib/src/enum_utils.dart
@@ -14,7 +14,36 @@ import 'utils.dart';
 String constMapName(DartType targetType) =>
     '_\$${targetType.element2!.name}EnumMap';
 
+/// If [targetType] is not an enum, return `null`.
+///
+/// Otherwise, returns `true` if one of the encoded values of the enum is
+/// `null`.
+bool? enumFieldWithNullInEncodeMap(DartType targetType) {
+  final enumMap = _enumMap(targetType);
+
+  if (enumMap == null) return null;
+
+  return enumMap.values.contains(null);
+}
+
 String? enumValueMapFromType(
+  DartType targetType, {
+  bool nullWithNoAnnotation = false,
+}) {
+  final enumMap =
+      _enumMap(targetType, nullWithNoAnnotation: nullWithNoAnnotation);
+
+  if (enumMap == null) return null;
+
+  final items = enumMap.entries
+      .map((e) => '  ${targetType.element2!.name}.${e.key.name}: '
+          '${jsonLiteralAsDart(e.value)},')
+      .join();
+
+  return 'const ${constMapName(targetType)} = {\n$items\n};';
+}
+
+Map<FieldElement, Object?>? _enumMap(
   DartType targetType, {
   bool nullWithNoAnnotation = false,
 }) {
@@ -27,7 +56,7 @@ String? enumValueMapFromType(
     return null;
   }
 
-  final enumMap = {
+  return {
     for (var field in enumFields)
       field: _generateEntry(
         field: field,
@@ -35,13 +64,6 @@ String? enumValueMapFromType(
         targetType: targetType,
       ),
   };
-
-  final items = enumMap.entries
-      .map((e) => '  ${targetType.element2!.name}.${e.key.name}: '
-          '${jsonLiteralAsDart(e.value)},')
-      .join();
-
-  return 'const ${constMapName(targetType)} = {\n$items\n};';
 }
 
 Object? _generateEntry({

--- a/json_serializable/lib/src/type_helper_ctx.dart
+++ b/json_serializable/lib/src/type_helper_ctx.dart
@@ -135,12 +135,11 @@ ConvertData? _convertData(DartObject obj, FieldElement element, bool isFrom) {
         'positional parameter.');
   }
 
+  final returnType = executableElement.returnType;
   final argType = executableElement.parameters.first.type;
   if (isFrom) {
     final hasDefaultValue =
         !jsonKeyAnnotation(element).read('defaultValue').isNull;
-
-    final returnType = executableElement.returnType;
 
     if (returnType is TypeParameterType) {
       // We keep things simple in this case. We rely on inferred type arguments
@@ -176,5 +175,5 @@ ConvertData? _convertData(DartObject obj, FieldElement element, bool isFrom) {
     }
   }
 
-  return ConvertData(executableElement.qualifiedName, argType);
+  return ConvertData(executableElement.qualifiedName, argType, returnType);
 }

--- a/json_serializable/lib/src/type_helpers/convert_helper.dart
+++ b/json_serializable/lib/src/type_helpers/convert_helper.dart
@@ -14,8 +14,9 @@ import '../type_helper.dart';
 class ConvertData {
   final String name;
   final DartType paramType;
+  final DartType returnType;
 
-  ConvertData(this.name, this.paramType);
+  ConvertData(this.name, this.paramType, this.returnType);
 }
 
 abstract class TypeHelperContextWithConvert extends TypeHelperContext {

--- a/json_serializable/lib/src/type_helpers/enum_helper.dart
+++ b/json_serializable/lib/src/type_helpers/enum_helper.dart
@@ -29,7 +29,8 @@ class EnumHelper extends TypeHelper<TypeHelperContextWithConfig> {
 
     context.addMember(memberContent);
 
-    if (targetType.isNullableType) {
+    if (targetType.isNullableType ||
+        enumFieldWithNullInEncodeMap(targetType) == true) {
       return '${constMapName(targetType)}[$expression]';
     } else {
       return '${constMapName(targetType)}[$expression]!';

--- a/json_serializable/lib/src/type_helpers/json_converter_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_converter_helper.dart
@@ -143,6 +143,24 @@ class _JsonConvertData {
       accessor.isEmpty ? '' : '.$accessor';
 }
 
+/// If there is no converter for the params, return `null`.
+///
+/// Otherwise, returns `true` if the converter has a null return value.
+///
+/// Used to make sure we create a smart encoding function.
+bool? hasConverterNullEncode(
+  DartType targetType,
+  TypeHelperContextWithConfig ctx,
+) {
+  final data = _typeConverter(targetType, ctx);
+
+  if (data == null) {
+    return null;
+  }
+
+  return data.jsonType.isNullableType;
+}
+
 _JsonConvertData? _typeConverter(
   DartType targetType,
   TypeHelperContextWithConfig ctx,

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 6.5.1
+version: 6.5.2
 description: >-
   Automatically generate code for converting to and from JSON by annotating
   Dart classes.

--- a/json_serializable/test/integration/converter_examples.dart
+++ b/json_serializable/test/integration/converter_examples.dart
@@ -1,0 +1,97 @@
+import 'dart:convert';
+
+import 'package:json_annotation/json_annotation.dart';
+
+part 'converter_examples.g.dart';
+
+@JsonEnum(valueField: 'value')
+enum Issue1202RegressionEnum {
+  normalValue(42),
+  nullValue(null);
+
+  const Issue1202RegressionEnum(this.value);
+
+  final int? value;
+}
+
+@JsonSerializable(includeIfNull: false)
+class Issue1202RegressionClass {
+  @JsonKey(fromJson: _fromJson, toJson: _toJson)
+  final int valueWithFunctions;
+
+  @_Issue1202RegressionNotNullConverter()
+  final int notNullableValueWithConverter;
+
+  final Issue1202RegressionEnum value;
+  final int? normalNullableValue;
+
+  @_Issue1202RegressionConverter()
+  final int notNullableValueWithNullableConverter;
+
+  @JsonKey(fromJson: _fromJsonNullable, toJson: _toJsonNullable)
+  final int valueWithNullableFunctions;
+
+  Issue1202RegressionClass({
+    required this.value,
+    required this.normalNullableValue,
+    required this.notNullableValueWithNullableConverter,
+    required this.notNullableValueWithConverter,
+    required this.valueWithFunctions,
+    required this.valueWithNullableFunctions,
+  });
+
+  factory Issue1202RegressionClass.fromJson(Map<String, dynamic> json) =>
+      _$Issue1202RegressionClassFromJson(json);
+
+  Map<String, dynamic> toJson() => _$Issue1202RegressionClassToJson(this);
+
+  @override
+  bool operator ==(Object other) =>
+      other is Issue1202RegressionClass &&
+      jsonEncode(other) == jsonEncode(this);
+
+  @override
+  int get hashCode => jsonEncode(this).hashCode;
+
+  static int _fromJsonNullable(String? json) {
+    if (json == null) return _default;
+    return int.parse(json);
+  }
+
+  static String? _toJsonNullable(int object) {
+    if (object == _default) return null;
+    return object.toString();
+  }
+
+  static int _fromJson(String json) => int.parse(json);
+
+  static String _toJson(int object) => object.toString();
+}
+
+const _default = 42;
+
+class _Issue1202RegressionConverter extends JsonConverter<int, String?> {
+  const _Issue1202RegressionConverter();
+
+  @override
+  int fromJson(String? json) {
+    if (json == null) return _default;
+    return int.parse(json);
+  }
+
+  @override
+  String? toJson(int object) {
+    if (object == _default) return null;
+    return object.toString();
+  }
+}
+
+class _Issue1202RegressionNotNullConverter extends JsonConverter<int, String> {
+  const _Issue1202RegressionNotNullConverter();
+
+  @override
+  int fromJson(String json) => int.parse(json);
+
+  @override
+  String toJson(int object) => object.toString();
+}

--- a/json_serializable/test/integration/converter_examples.g.dart
+++ b/json_serializable/test/integration/converter_examples.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: lines_longer_than_80_chars, text_direction_code_point_in_literal
+
+part of 'converter_examples.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Issue1202RegressionClass _$Issue1202RegressionClassFromJson(
+        Map<String, dynamic> json) =>
+    Issue1202RegressionClass(
+      value: $enumDecode(_$Issue1202RegressionEnumEnumMap, json['value']),
+      normalNullableValue: json['normalNullableValue'] as int?,
+      notNullableValueWithNullableConverter:
+          const _Issue1202RegressionConverter().fromJson(
+              json['notNullableValueWithNullableConverter'] as String?),
+      notNullableValueWithConverter:
+          const _Issue1202RegressionNotNullConverter()
+              .fromJson(json['notNullableValueWithConverter'] as String),
+      valueWithFunctions: Issue1202RegressionClass._fromJson(
+          json['valueWithFunctions'] as String),
+      valueWithNullableFunctions: Issue1202RegressionClass._fromJsonNullable(
+          json['valueWithNullableFunctions'] as String?),
+    );
+
+Map<String, dynamic> _$Issue1202RegressionClassToJson(
+    Issue1202RegressionClass instance) {
+  final val = <String, dynamic>{
+    'valueWithFunctions':
+        Issue1202RegressionClass._toJson(instance.valueWithFunctions),
+    'notNullableValueWithConverter':
+        const _Issue1202RegressionNotNullConverter()
+            .toJson(instance.notNullableValueWithConverter),
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('value', _$Issue1202RegressionEnumEnumMap[instance.value]);
+  writeNotNull('normalNullableValue', instance.normalNullableValue);
+  writeNotNull(
+      'notNullableValueWithNullableConverter',
+      const _Issue1202RegressionConverter()
+          .toJson(instance.notNullableValueWithNullableConverter));
+  writeNotNull(
+      'valueWithNullableFunctions',
+      Issue1202RegressionClass._toJsonNullable(
+          instance.valueWithNullableFunctions));
+  return val;
+}
+
+const _$Issue1202RegressionEnumEnumMap = {
+  Issue1202RegressionEnum.normalValue: 42,
+  Issue1202RegressionEnum.nullValue: null,
+};

--- a/json_serializable/test/integration/integration_test.dart
+++ b/json_serializable/test/integration/integration_test.dart
@@ -6,6 +6,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:test/test.dart';
 
 import '../test_utils.dart';
+import 'converter_examples.dart';
 import 'field_map_example.dart';
 import 'json_enum_example.dart';
 import 'json_test_common.dart' show Category, Platform, StatusCode;
@@ -357,5 +358,60 @@ void main() {
       privateModelFieldMap,
       {'fullName': 'full-name'},
     );
+  });
+
+  group('classes with converters', () {
+    Issue1202RegressionClass roundTripIssue1202RegressionClass(int value) {
+      final instance = Issue1202RegressionClass(
+        normalNullableValue: value,
+        notNullableValueWithConverter: value,
+        notNullableValueWithNullableConverter: value,
+        value: Issue1202RegressionEnum.normalValue,
+        valueWithFunctions: value,
+        valueWithNullableFunctions: value,
+      );
+      return roundTripObject(instance, Issue1202RegressionClass.fromJson);
+    }
+
+    test('With default values', () {
+      final thing = roundTripIssue1202RegressionClass(42);
+
+      expect(thing.toJson(), {
+        'valueWithFunctions': '42',
+        'notNullableValueWithConverter': '42',
+        'value': 42,
+        'normalNullableValue': 42,
+      });
+    });
+
+    test('With non-default values', () {
+      final thing = roundTripIssue1202RegressionClass(43);
+
+      expect(thing.toJson(), {
+        'valueWithFunctions': '43',
+        'notNullableValueWithConverter': '43',
+        'value': 42,
+        'normalNullableValue': 43,
+        'notNullableValueWithNullableConverter': '43',
+        'valueWithNullableFunctions': '43',
+      });
+    });
+
+    test('enum with null value', () {
+      final instance = Issue1202RegressionClass(
+        normalNullableValue: 42,
+        notNullableValueWithConverter: 42,
+        notNullableValueWithNullableConverter: 42,
+        value: Issue1202RegressionEnum.nullValue,
+        valueWithFunctions: 42,
+        valueWithNullableFunctions: 42,
+      );
+
+      expect(instance.toJson(), {
+        'valueWithFunctions': '42',
+        'notNullableValueWithConverter': '42',
+        'normalNullableValue': 42,
+      });
+    });
   });
 }

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_exclude_null.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_exclude_null.g.dart
@@ -190,13 +190,11 @@ Map<String, dynamic> _$JsonConverterTestClassToJson(
   val['durationList'] = instance.durationList
       .map(const DurationMillisecondConverter().toJson)
       .toList();
-  writeNotNull('bigInt', const BigIntStringConverter().toJson(instance.bigInt));
+  val['bigInt'] = const BigIntStringConverter().toJson(instance.bigInt);
   val['bigIntMap'] = instance.bigIntMap
       .map((k, e) => MapEntry(k, const BigIntStringConverter().toJson(e)));
-  writeNotNull(
-      'nullableBigInt',
-      _$JsonConverterToJson<String, BigInt>(
-          instance.nullableBigInt, const BigIntStringConverter().toJson));
+  val['nullableBigInt'] = _$JsonConverterToJson<String, BigInt>(
+      instance.nullableBigInt, const BigIntStringConverter().toJson);
   val['nullableBigIntMap'] = instance.nullableBigIntMap.map((k, e) => MapEntry(
       k,
       _$JsonConverterToJson<String, BigInt>(
@@ -247,19 +245,10 @@ JsonConverterGeneric<S, T, U> _$JsonConverterGenericFromJson<S, T, U>(
     );
 
 Map<String, dynamic> _$JsonConverterGenericToJson<S, T, U>(
-    JsonConverterGeneric<S, T, U> instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('item', GenericConverter<S>().toJson(instance.item));
-  val['itemList'] =
-      instance.itemList.map(GenericConverter<T>().toJson).toList();
-  val['itemMap'] = instance.itemMap
-      .map((k, e) => MapEntry(k, GenericConverter<U>().toJson(e)));
-  return val;
-}
+        JsonConverterGeneric<S, T, U> instance) =>
+    <String, dynamic>{
+      'item': GenericConverter<S>().toJson(instance.item),
+      'itemList': instance.itemList.map(GenericConverter<T>().toJson).toList(),
+      'itemMap': instance.itemMap
+          .map((k, e) => MapEntry(k, GenericConverter<U>().toJson(e))),
+    };

--- a/json_serializable/test/src/to_from_json_test_input.dart
+++ b/json_serializable/test/src/to_from_json_test_input.dart
@@ -170,6 +170,8 @@ class TypedConvertMethods {
   late String field;
 }
 
+String? _toStringNullOnEmpty(String input) => input.isEmpty ? null : input;
+
 @ShouldGenerate(
   r'''
 Map<String, dynamic> _$ToJsonNullableFalseIncludeIfNullFalseToJson(
@@ -182,14 +184,14 @@ Map<String, dynamic> _$ToJsonNullableFalseIncludeIfNullFalseToJson(
     }
   }
 
-  writeNotNull('field', _toString(instance.field));
+  writeNotNull('field', _toStringNullOnEmpty(instance.field));
   return val;
 }
 ''',
 )
 @JsonSerializable(createFactory: false)
 class ToJsonNullableFalseIncludeIfNullFalse {
-  @JsonKey(toJson: _toString, includeIfNull: false)
+  @JsonKey(toJson: _toStringNullOnEmpty, includeIfNull: false)
   late String field;
 }
 


### PR DESCRIPTION
Specifically with enums and converter functions when
`includeIfNull` is `false`.

Enum values with `null` as an output where not properly wrapped.
This is now fixed.

Fixes https://github.com/google/json_serializable.dart/issues/1202

Also 'unwrap' the cases where conversion functions never return `null`.
