### PR TITLE
Support `JsonEnum.valueField` being set with `'index'`

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 6.6.0-dev
 
+- Support `JsonEnum.valueField` being set with `'index'`.
 - Require Dart SDK `>=2.18.0`.
 - Require `analyzer: ^5.2.0`
 - Require `json_annotation: '>=4.8.0 <4.9.0'`

--- a/json_serializable/lib/src/enum_utils.dart
+++ b/json_serializable/lib/src/enum_utils.dart
@@ -88,6 +88,20 @@ Object? _generateEntry({
 
       final e = fieldElementType.getField(valueField);
 
+      if (e == null && valueField == 'index') {
+        final values = fieldElementType.getField('values')!;
+
+        final items = ConstantReader(values.computeConstantValue()).listValue;
+
+        return items
+            .singleWhere((element) {
+              final name = element.getField('_name')!.toStringValue()!;
+              return name == field.name;
+            })
+            .getField('index')!
+            .toIntValue()!;
+      }
+
       if (e == null || e.isStatic) {
         throw InvalidGenerationSourceError(
           '`JsonEnum.valueField` was set to "$valueField", but '

--- a/json_serializable/lib/src/enum_utils.dart
+++ b/json_serializable/lib/src/enum_utils.dart
@@ -89,17 +89,10 @@ Object? _generateEntry({
       final e = fieldElementType.getField(valueField);
 
       if (e == null && valueField == 'index') {
-        final values = fieldElementType.getField('values')!;
-
-        final items = ConstantReader(values.computeConstantValue()).listValue;
-
-        return items
-            .singleWhere((element) {
-              final name = element.getField('_name')!.toStringValue()!;
-              return name == field.name;
-            })
-            .getField('index')!
-            .toIntValue()!;
+        return fieldElementType.fields
+            .where((element) => element.isEnumConstant)
+            .toList(growable: false)
+            .indexOf(field);
       }
 
       if (e == null || e.isStatic) {

--- a/json_serializable/test/integration/integration_test.dart
+++ b/json_serializable/test/integration/integration_test.dart
@@ -467,4 +467,8 @@ void main() {
     final instance = Regression1229();
     expect(instance.toJson(), isEmpty);
   });
+
+  test('value field index fun', () {
+    expect(enumValueFieldIndexValues, [0, 701, 2]);
+  });
 }

--- a/json_serializable/test/integration/json_enum_example.dart
+++ b/json_serializable/test/integration/json_enum_example.dart
@@ -38,6 +38,23 @@ enum MyStatusCode {
 
 Iterable<int> get myStatusCodeEnumValues => _$MyStatusCodeEnumMap.values;
 
+@JsonEnum(alwaysCreate: true, valueField: 'index')
+enum EnumValueFieldIndex {
+  success(200),
+  @JsonValue(701) // explicit value always takes precedence
+  weird(601),
+  oneMore(777);
+
+  static const tryingToBeConfusing = weird;
+
+  const EnumValueFieldIndex(this.value);
+
+  final int value;
+}
+
+Iterable<int> get enumValueFieldIndexValues =>
+    _$EnumValueFieldIndexEnumMap.values;
+
 @JsonSerializable(
   createToJson: false,
 )

--- a/json_serializable/test/integration/json_enum_example.g.dart
+++ b/json_serializable/test/integration/json_enum_example.g.dart
@@ -84,3 +84,9 @@ const _$MyStatusCodeEnumMap = {
   MyStatusCode.success: 200,
   MyStatusCode.weird: 701,
 };
+
+const _$EnumValueFieldIndexEnumMap = {
+  EnumValueFieldIndex.success: 0,
+  EnumValueFieldIndex.weird: 701,
+  EnumValueFieldIndex.oneMore: 2,
+};


### PR DESCRIPTION
Fixes https://github.com/google/json_serializable.dart/issues/1249
