### PR TITLE
Unify dart and flutter generation instructions

### DIFF
--- a/json_serializable/README.md
+++ b/json_serializable/README.md
@@ -75,10 +75,7 @@ Map<String, dynamic> _$PersonToJson(Person instance) => <String, dynamic>{
 Once you have added the annotations to your code you then need to run the code
 generator to generate the missing `.g.dart` generated dart files.
 
-With a Dart package, run `dart run build_runner build` in the package directory.
-
-With a Flutter package, run `flutter pub run build_runner build` in your package
-directory.
+Run `dart run build_runner build` in the package directory.
 
 # Annotation values
 

--- a/json_serializable/tool/readme/readme_template.md
+++ b/json_serializable/tool/readme/readme_template.md
@@ -35,10 +35,7 @@ Building creates the corresponding part `example.g.dart`:
 Once you have added the annotations to your code you then need to run the code
 generator to generate the missing `.g.dart` generated dart files.
 
-With a Dart package, run `dart run build_runner build` in the package directory.
-
-With a Flutter package, run `flutter pub run build_runner build` in your package
-directory.
+Run `dart run build_runner build` in the package directory.
 
 # Annotation values
 


### PR DESCRIPTION
When using `flutter pub run ...` it prints "Deprecated. Use `dart run` instead." (flutter 3.10) so this removes the instructions for flutter and just instructions and just use `dart run ...`