### PR TITLE
fix: update pub_semver and build_runner version

### DIFF
--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   json_annotation: '>=4.8.1 <4.9.0'
   meta: ^1.3.0
   path: ^1.8.0
-  pub_semver: ^2.0.0
+  pub_semver: ^2.1.3
   pubspec_parse: ^1.0.0
   source_gen: ^1.3.2
   source_helper: ^1.3.0
@@ -32,7 +32,7 @@ dependencies:
 dev_dependencies:
   _json_serial_shared_test:
     path: ../shared_test
-  build_runner: ^2.0.0
+  build_runner: ^2.3.3
   build_verify: ^3.0.0
   dart_flutter_team_lints: ^1.0.0
   dart_style: ^2.0.0


### PR DESCRIPTION
Older versions of `build_runner` and `pub_semver` report the following error when executing `dart run build_runner`. So need to update them.

```
Building package executable... (4.1s)
Failed to build build_runner:build_runner:
/Users/ipcjs/.pub-cache/hosted/pub.dev/build_runner-2.3.2/lib/src/build_script_generate/bootstrap.dart:76:40: Error: Method not found: 'NullThrownError'.
      final error = e[0] as Object? ?? NullThrownError();
                                       ^^^^^^^^^^^^^^^
/Users/ipcjs/.pub-cache/hosted/pub.dev/pub_semver-2.1.1/lib/src/version_constraint.dart:96:13: Error: Method not found: 'FallThroughError'.
      throw FallThroughError();
            ^^^^^^^^^^^^^^^^
```