### PR TITLE
Add `Example.property` field to docstring in example for `JsonConverter` class

### DIFF
--- a/json_annotation/lib/src/json_converter.dart
+++ b/json_annotation/lib/src/json_converter.dart
@@ -19,7 +19,9 @@
 ///
 /// @JsonSerializable()
 /// @MyJsonConverter()
-/// class Example {}
+/// class Example {
+///   final Value property;
+/// }
 /// ```
 ///
 /// or on a property:
@@ -36,7 +38,9 @@
 ///
 /// ```dart
 /// @JsonSerializable(converters: [MyJsonConverter()])
-/// class Example {}
+/// class Example {
+///   final Value property;
+/// }
 /// ```
 abstract class JsonConverter<T, S> {
   const JsonConverter();


### PR DESCRIPTION
This makes the three examples consistent and shows more clearly the role of `MyJsonConverter`