### PR TITLE
select appropriate converter for nullable fieldtype

### DIFF
--- a/json_serializable/lib/src/type_helpers/json_converter_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_converter_helper.dart
@@ -202,6 +202,14 @@ _JsonConvertData? _typeConverterFrom(
     return null;
   }
 
+  if (targetType.isNullableType && matchingAnnotations.length == 2) {
+    final indexOfNonNullableConverter = matchingAnnotations
+        .indexWhere((element) => !element.fieldType.isNullableType);
+    if (indexOfNonNullableConverter >= 0) {
+      matchingAnnotations.removeAt(indexOfNonNullableConverter);
+    }
+  }
+
   if (matchingAnnotations.length > 1) {
     final targetTypeCode = typeToCode(targetType);
     throw InvalidGenerationSourceError(

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -91,6 +91,7 @@ const _expectedAnnotatedTests = {
   'JsonConvertOnField',
   'JsonConverterCtorParams',
   'JsonConverterDuplicateAnnotations',
+  'JsonConverterIssue1339',
   'JsonConverterNamedCtor',
   'JsonConverterNullableToNonNullable',
   'JsonConverterOnGetter',

--- a/json_serializable/test/src/json_converter_test_input.dart
+++ b/json_serializable/test/src/json_converter_test_input.dart
@@ -126,6 +126,38 @@ class JsonConverterDuplicateAnnotations {
   late Duration value;
 }
 
+@ShouldGenerate(r'''
+JsonConverterIssue1339 _$JsonConverterIssue1339FromJson(
+        Map<String, dynamic> json) =>
+    JsonConverterIssue1339()
+      ..value =
+          const _DurationMillisecondConverter().fromJson(json['value'] as int)
+      ..nullableValue = _$JsonConverterFromJson<int, Duration?>(
+          json['nullableValue'],
+          const _DurationMillisecondNullConverter().fromJson);
+
+Map<String, dynamic> _$JsonConverterIssue1339ToJson(
+        JsonConverterIssue1339 instance) =>
+    <String, dynamic>{
+      'value': const _DurationMillisecondConverter().toJson(instance.value),
+      'nullableValue': const _DurationMillisecondNullConverter()
+          .toJson(instance.nullableValue),
+    };
+
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) =>
+    json == null ? null : fromJson(json as Json);
+''')
+@JsonSerializable()
+@_DurationMillisecondNullConverter()
+@_DurationMillisecondConverter()
+class JsonConverterIssue1339 {
+  late Duration value;
+  late Duration? nullableValue;
+}
+
 const _durationConverter = _DurationMillisecondConverter();
 
 class _DurationMillisecondConverter implements JsonConverter<Duration, int> {
@@ -138,6 +170,19 @@ class _DurationMillisecondConverter implements JsonConverter<Duration, int> {
 
   @override
   int toJson(Duration object) => throw UnimplementedError();
+}
+
+class _DurationMillisecondNullConverter
+    implements JsonConverter<Duration?, int> {
+  const _DurationMillisecondNullConverter();
+
+  const _DurationMillisecondNullConverter.named();
+
+  @override
+  Duration? fromJson(int json) => throw UnimplementedError();
+
+  @override
+  int toJson(Duration? object) => throw UnimplementedError();
 }
 
 @ShouldThrow(


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1339 

## Solution description
When `targetType` is nullable and the class is annotated with both converters for nullable and non-nullable type, `_compatibleMatch` returns two of them. So I've added a check if `targetType` is nullable and `matchingAnnotations` length is equal to 2, if so I proceed to try to find a non-null converter and remove it from the list of `matchedConverters`. 


## To Do

- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme