### PR TITLE
Improve error messages when typeToCode throws an exception

### DIFF
--- a/json_serializable/lib/src/helper_core.dart
+++ b/json_serializable/lib/src/helper_core.dart
@@ -75,7 +75,11 @@ $converterOrKeyInstructions
 * Set `JsonSerializable.genericArgumentFactories` to `true`
   https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/genericArgumentFactories.html''';
   } else if (field.type != error.type) {
-    message = '$message because of type `${typeToCode(error.type)}`';
+    try {
+      message = '$message because of type `${typeToCode(error.type)}`';
+    } catch (ex) {
+      message = '$message because of type is unimplemented/unsupported/undefined';
+    }
   } else {
     final element = error.type.element?.name;
     todo = '''


### PR DESCRIPTION
`typeToCode` can throw an expection, which reduces the error message to:

```
UnimplementedError: (InvalidTypeImpl) InvalidType
package:json_serializable/src/utils.dart 221:3              typeToCode
package:json_serializable/src/helper_core.dart 79:46        createInvalidGenerationError
...
```

This change improves the error message to something like this:

```
Could not generate `fromJson` code for `photos` because of type is unimplemented/unsupported/undefined.
package:picthrive_kiosk/ptclient/generated/consolidated_public.swagger.dart:2633:21
     ╷
2633 │   final List<Items> photos;
     │                     ^^^^^^
     ╵

```