### PR TITLE
Update README.md

### DIFF
--- a/json_serializable/README.md
+++ b/json_serializable/README.md
@@ -287,6 +287,18 @@ targets:
           include_if_null: true
 ```
 
+To exclude generated files from coverage, you can further configure `build.yaml`.
+
+```yaml
+targets:
+  $default:
+    builders:
+      source_gen:combining_builder:
+        options:
+          preamble: |
+            // coverage:ignore-file
+```
+
 [example]: https://github.com/google/json_serializable.dart/tree/master/example
 [dart build system]: https://github.com/dart-lang/build
 [package:json_annotation]: https://pub.dev/packages/json_annotation

--- a/json_serializable/tool/readme/readme_template.md
+++ b/json_serializable/tool/readme/readme_template.md
@@ -152,6 +152,18 @@ targets:
           include_if_null: true
 ```
 
+To exclude generated files from coverage, you can further configure `build.yaml`.
+
+```yaml
+targets:
+  $default:
+    builders:
+      source_gen:combining_builder:
+        options:
+          preamble: |
+            // coverage:ignore-file
+```
+
 [example]: https://github.com/google/json_serializable.dart/tree/master/example
 [dart build system]: https://github.com/dart-lang/build
 [package:json_annotation]: https://pub.dev/packages/json_annotation


### PR DESCRIPTION
This seems to be a common question that is quite difficult to answer. The most visible solution I found previously was to use the `remove_from_coverage` package to remove generated files from the coverage report. That solution complicates CLI commands and may require updating CI/CD pipelines.