### PR TITLE
Allow `@JsonKey` to be used on constructor parameters

### DIFF
--- a/json_annotation/CHANGELOG.md
+++ b/json_annotation/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.9.1-wip
 
 - Require Dart 3.8
+- Support `JsonKey` annotation on constructor parameters.
 
 ## 4.9.0
 

--- a/json_annotation/lib/src/json_key.dart
+++ b/json_annotation/lib/src/json_key.dart
@@ -8,7 +8,7 @@ import 'allowed_keys_helpers.dart';
 import 'json_serializable.dart';
 
 /// An annotation used to specify how a field is serialized.
-@Target({TargetKind.field, TargetKind.getter})
+@Target({TargetKind.field, TargetKind.getter, TargetKind.parameter})
 class JsonKey {
   /// The value to use if the source JSON does not contain this key or if the
   /// value is `null`.

--- a/json_annotation/lib/src/json_key.dart
+++ b/json_annotation/lib/src/json_key.dart
@@ -8,6 +8,9 @@ import 'allowed_keys_helpers.dart';
 import 'json_serializable.dart';
 
 /// An annotation used to specify how a field is serialized.
+/// 
+/// This annotation can be used on both class properties and constructor
+/// parameters.
 @Target({TargetKind.field, TargetKind.getter, TargetKind.parameter})
 class JsonKey {
   /// The value to use if the source JSON does not contain this key or if the

--- a/json_annotation/lib/src/json_key.dart
+++ b/json_annotation/lib/src/json_key.dart
@@ -8,7 +8,7 @@ import 'allowed_keys_helpers.dart';
 import 'json_serializable.dart';
 
 /// An annotation used to specify how a field is serialized.
-/// 
+///
 /// This annotation can be used on both class properties and constructor
 /// parameters.
 @Target({TargetKind.field, TargetKind.getter, TargetKind.parameter})

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.10.1
+
+- Support `JsonKey` annotation on constructor parameters.
+
 ## 6.10.0
 
 - Required `analyzer: ^7.4.0`.

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.10.1
+## 6.11.0
 
 - Support `JsonKey` annotation on constructor parameters.
 

--- a/json_serializable/lib/src/json_key_utils.dart
+++ b/json_serializable/lib/src/json_key_utils.dart
@@ -25,9 +25,9 @@ KeyConfig jsonKeyForField(FieldElement2 field, ClassConfig classAnnotation) =>
 
 KeyConfig _from(FieldElement2 element, ClassConfig classAnnotation) {
   final obj = jsonKeyAnnotation(element);
-  final ctorParam = <FormalParameterElement?>[
-    ...classAnnotation.ctorParams,
-  ].singleWhere((e) => e!.name3 == element.name3, orElse: () => null);
+  final ctorParam = classAnnotation.ctorParams
+      .where((e) => e.name3 == element.name3)
+      .singleOrNull;
   final ctorObj = ctorParam == null
       ? null
       : jsonKeyAnnotationForCtorParam(ctorParam);

--- a/json_serializable/lib/src/json_key_utils.dart
+++ b/json_serializable/lib/src/json_key_utils.dart
@@ -80,7 +80,7 @@ KeyConfig _from(FieldElement2 element, ClassConfig classAnnotation) {
       // literal, which is NOT supported!
       badType = 'Function';
     } else if (!reader.isLiteral) {
-      badType = dartObject.type!.element3?.name3;
+      badType = dartObject.type!.element3?.name3!;
     }
 
     if (badType != null) {
@@ -208,7 +208,7 @@ KeyConfig _from(FieldElement2 element, ClassConfig classAnnotation) {
         (n) => n,
       );
 
-      return '${annotationType.element3!.name3}.$enumValueName';
+      return '${annotationType.element3!.name3!}.$enumValueName';
     } else {
       final defaultValueLiteral = literalForObject(fieldName, objectValue, []);
       if (defaultValueLiteral == null) {
@@ -228,12 +228,12 @@ KeyConfig _from(FieldElement2 element, ClassConfig classAnnotation) {
   if (defaultValue != null && ctorParamDefault != null) {
     if (defaultValue == ctorParamDefault) {
       log.info(
-        'The default value `$defaultValue` for `${element.name3}` is defined '
+        'The default value `$defaultValue` for `${element.name3!}` is defined '
         'twice in the constructor and in the `JsonKey.defaultValue`.',
       );
     } else {
       log.warning(
-        'The constructor parameter for `${element.name3}` has a default value '
+        'The constructor parameter for `${element.name3!}` has a default value '
         '`$ctorParamDefault`, but the `JsonKey.defaultValue` value '
         '`$defaultValue` will be used for missing or `null` values in JSON '
         'decoding.',

--- a/json_serializable/lib/src/json_key_utils.dart
+++ b/json_serializable/lib/src/json_key_utils.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
@@ -151,14 +150,14 @@ KeyConfig _from(FieldElement2 element, ClassConfig classAnnotation) {
       // the generated code will be invalid, so skipping until we're bored
       // later
 
-      final functionValue = objectValue.toFunctionValue()!;
+      final functionValue = objectValue.toFunctionValue2()!;
 
       final invokeConst =
-          functionValue is ConstructorElement && functionValue.isConst
+          functionValue is ConstructorElement2 && functionValue.isConst
           ? 'const '
           : '';
 
-      return '$invokeConst${functionValue.name}()';
+      return '$invokeConst${functionValue.qualifiedName}()';
     }
 
     final enumFields = iterateEnumFields(annotationType);

--- a/json_serializable/lib/src/json_key_utils.dart
+++ b/json_serializable/lib/src/json_key_utils.dart
@@ -25,8 +25,9 @@ KeyConfig jsonKeyForField(FieldElement field, ClassConfig classAnnotation) =>
 
 KeyConfig _from(FieldElement element, ClassConfig classAnnotation) {
   final obj = jsonKeyAnnotation(element);
-  final ctorParam = <ParameterElement?>[...classAnnotation.ctorParams]
-      .singleWhere((e) => e!.name == element.name, orElse: () => null);
+  final ctorParam = <ParameterElement?>[
+    ...classAnnotation.ctorParams,
+  ].singleWhere((e) => e!.name == element.name, orElse: () => null);
   final ctorObj = ctorParam == null
       ? null
       : jsonKeyAnnotationForCtorParam(ctorParam);
@@ -249,7 +250,8 @@ KeyConfig _from(FieldElement element, ClassConfig classAnnotation) {
   }
 
   final ignore = fallbackObjRead('ignore').literalValue as bool?;
-  var includeFromJson = fallbackObjRead('includeFromJson').literalValue as bool?;
+  var includeFromJson =
+      fallbackObjRead('includeFromJson').literalValue as bool?;
   var includeToJson = fallbackObjRead('includeToJson').literalValue as bool?;
 
   if (ignore != null) {
@@ -275,7 +277,8 @@ KeyConfig _from(FieldElement element, ClassConfig classAnnotation) {
     classAnnotation,
     element,
     defaultValue: defaultValue ?? ctorParamDefault,
-    disallowNullValue: fallbackObjRead('disallowNullValue').literalValue as bool?,
+    disallowNullValue:
+        fallbackObjRead('disallowNullValue').literalValue as bool?,
     includeIfNull: fallbackObjRead('includeIfNull').literalValue as bool?,
     name: fallbackObjRead('name').literalValue as String?,
     readValueFunctionName: readValueFunctionName,

--- a/json_serializable/lib/src/json_key_utils.dart
+++ b/json_serializable/lib/src/json_key_utils.dart
@@ -80,7 +80,7 @@ KeyConfig _from(FieldElement2 element, ClassConfig classAnnotation) {
       // literal, which is NOT supported!
       badType = 'Function';
     } else if (!reader.isLiteral) {
-      badType = dartObject.type!.element?.name;
+      badType = dartObject.type!.element3?.name3;
     }
 
     if (badType != null) {
@@ -208,7 +208,7 @@ KeyConfig _from(FieldElement2 element, ClassConfig classAnnotation) {
         (n) => n,
       );
 
-      return '${annotationType.element!.name}.$enumValueName';
+      return '${annotationType.element3!.name3}.$enumValueName';
     } else {
       final defaultValueLiteral = literalForObject(fieldName, objectValue, []);
       if (defaultValueLiteral == null) {
@@ -244,7 +244,9 @@ KeyConfig _from(FieldElement2 element, ClassConfig classAnnotation) {
   String? readValueFunctionName;
   final readValue = fallbackObjRead('readValue');
   if (!readValue.isNull) {
-    readValueFunctionName = readValue.objectValue.toFunctionValue()!.name;
+    readValueFunctionName = readValue.objectValue
+        .toFunctionValue2()!
+        .qualifiedName;
   }
 
   final ignore = fallbackObjRead('ignore').literalValue as bool?;
@@ -345,7 +347,7 @@ bool _includeIfNull(
 bool _interfaceTypesEqual(DartType a, DartType b) {
   if (a is InterfaceType && b is InterfaceType) {
     // Handle nullability case. Pretty sure this is fine for enums.
-    return a.element == b.element;
+    return a.element3 == b.element3;
   }
   return a == b;
 }

--- a/json_serializable/lib/src/json_key_utils.dart
+++ b/json_serializable/lib/src/json_key_utils.dart
@@ -35,7 +35,17 @@ KeyConfig _from(FieldElement2 element, ClassConfig classAnnotation) {
   ConstantReader fallbackObjRead(String field) {
     if (ctorObj != null && !ctorObj.isNull) {
       final ctorReadResult = ctorObj.read(field);
-      if (!ctorReadResult.isNull) return ctorReadResult;
+      if (!ctorReadResult.isNull)  {
+        if (!obj.isNull && !obj.read(field).isNull) {
+            log.warning(
+              'Field `${element.name3}` has conflicting `JsonKey.$field` '
+              'annotations: both constructor parameter and class field have '
+              'this annotation. Using constructor parameter value.',
+            );
+        }
+
+        return ctorReadResult;
+      }
     }
     if (obj.isNull) {
       return ConstantReader(null);

--- a/json_serializable/lib/src/json_key_utils.dart
+++ b/json_serializable/lib/src/json_key_utils.dart
@@ -35,13 +35,13 @@ KeyConfig _from(FieldElement2 element, ClassConfig classAnnotation) {
   ConstantReader fallbackObjRead(String field) {
     if (ctorObj != null && !ctorObj.isNull) {
       final ctorReadResult = ctorObj.read(field);
-      if (!ctorReadResult.isNull)  {
+      if (!ctorReadResult.isNull) {
         if (!obj.isNull && !obj.read(field).isNull) {
-            log.warning(
-              'Field `${element.name3}` has conflicting `JsonKey.$field` '
-              'annotations: both constructor parameter and class field have '
-              'this annotation. Using constructor parameter value.',
-            );
+          log.warning(
+            'Field `${element.name3}` has conflicting `JsonKey.$field` '
+            'annotations: both constructor parameter and class field have '
+            'this annotation. Using constructor parameter value.',
+          );
         }
 
         return ctorReadResult;

--- a/json_serializable/lib/src/type_helpers/config_types.dart
+++ b/json_serializable/lib/src/type_helpers/config_types.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/constant/value.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 /// Represents values from [JsonKey] when merged with local configuration.
@@ -57,7 +58,7 @@ class ClassConfig {
   final bool genericArgumentFactories;
   final bool ignoreUnannotated;
   final bool includeIfNull;
-  final Map<String, String> ctorParamDefaults;
+  final List<ParameterElement> ctorParams;
   final List<DartObject> converters;
 
   const ClassConfig({
@@ -76,7 +77,7 @@ class ClassConfig {
     required this.ignoreUnannotated,
     required this.includeIfNull,
     this.converters = const [],
-    this.ctorParamDefaults = const {},
+    this.ctorParams = const [],
   });
 
   factory ClassConfig.fromJsonSerializable(JsonSerializable config) =>

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -14,8 +14,8 @@ import 'type_helpers/config_types.dart';
 
 const _jsonKeyChecker = TypeChecker.fromRuntime(JsonKey);
 
-// If an annotation exists on `element` the source is a 'real' field.
-// If the result is `null`, check the getter – it is a property.
+/// If an annotation exists on `element` the source is a 'real' field.
+/// If the result is `null`, check the getter – it is a property.
 // TODO: setters: github.com/google/json_serializable.dart/issues/24
 DartObject? _jsonKeyAnnotation(FieldElement2 element) =>
     _jsonKeyChecker.firstAnnotationOf(element) ??

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 6.10.0
+version: 6.11.0
 description: >-
   Automatically generate code for converting to and from JSON by annotating
   Dart classes.

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -49,6 +49,8 @@ const _expectedAnnotatedTests = {
   'BadToFuncReturnType',
   'BadTwoRequiredPositional',
   'CtorDefaultValueAndJsonKeyDefaultValue',
+  'CtorParamJsonKey',
+  'CtorParamJsonKeyWithExtends',
   'DefaultDoubleConstants',
   'DefaultWithConstObject',
   'DefaultWithDisallowNullRequiredClass',

--- a/json_serializable/test/src/_json_serializable_test_input.dart
+++ b/json_serializable/test/src/_json_serializable_test_input.dart
@@ -14,6 +14,7 @@ part 'constants_copy.dart';
 part 'core_subclass_type_input.dart';
 part 'default_value_input.dart';
 part 'field_namer_input.dart';
+part 'extends_jsonkey_override.dart';
 part 'generic_test_input.dart';
 part 'inheritance_test_input.dart';
 part 'json_converter_test_input.dart';

--- a/json_serializable/test/src/extends_jsonkey_override.dart
+++ b/json_serializable/test/src/extends_jsonkey_override.dart
@@ -15,7 +15,11 @@ Map<String, dynamic> _$CtorParamJsonKeyToJson(CtorParamJsonKey instance) =>
       'first': instance.attributeOne,
       'second': instance.attributeTwo,
     };
-''')
+''', expectedLogItems: [
+  'Field `attributeOne` has conflicting `JsonKey.name` annotations: both '
+  'constructor parameter and class field have this annotation. Using '
+  'constructor parameter value.',
+])
 @JsonSerializable()
 class CtorParamJsonKey {
   CtorParamJsonKey({

--- a/json_serializable/test/src/extends_jsonkey_override.dart
+++ b/json_serializable/test/src/extends_jsonkey_override.dart
@@ -1,0 +1,52 @@
+// @dart=3.8
+
+part of '_json_serializable_test_input.dart';
+
+// https://github.com/google/json_serializable.dart/issues/1437
+@ShouldGenerate(r'''
+CtorParamJsonKey _$CtorParamJsonKeyFromJson(Map<String, dynamic> json) =>
+    CtorParamJsonKey(
+      attributeOne: json['first'] as String,
+      attributeTwo: json['second'] as String,
+    );
+
+Map<String, dynamic> _$CtorParamJsonKeyToJson(CtorParamJsonKey instance) =>
+    <String, dynamic>{
+      'first': instance.attributeOne,
+      'second': instance.attributeTwo,
+    };
+''')
+@JsonSerializable()
+class CtorParamJsonKey {
+  CtorParamJsonKey({
+    @JsonKey(name: 'first') required this.attributeOne,
+    @JsonKey(name: 'second') required this.attributeTwo,
+  });
+
+  @JsonKey(name: 'fake_first')
+  final String attributeOne;
+  final String attributeTwo;
+}
+
+@ShouldGenerate(r'''
+CtorParamJsonKeyWithExtends _$CtorParamJsonKeyWithExtendsFromJson(
+  Map<String, dynamic> json,
+) => CtorParamJsonKeyWithExtends(
+  attributeOne: json['fake_first'] as String,
+  attributeTwo: json['two'] as String,
+);
+
+Map<String, dynamic> _$CtorParamJsonKeyWithExtendsToJson(
+  CtorParamJsonKeyWithExtends instance,
+) => <String, dynamic>{
+  'fake_first': instance.attributeOne,
+  'two': instance.attributeTwo,
+};
+''')
+@JsonSerializable()
+class CtorParamJsonKeyWithExtends extends CtorParamJsonKey {
+  CtorParamJsonKeyWithExtends({
+    required super.attributeOne,
+    @JsonKey(name: 'two') required super.attributeTwo,
+  });
+}

--- a/json_serializable/test/src/extends_jsonkey_override.dart
+++ b/json_serializable/test/src/extends_jsonkey_override.dart
@@ -3,7 +3,8 @@
 part of '_json_serializable_test_input.dart';
 
 // https://github.com/google/json_serializable.dart/issues/1437
-@ShouldGenerate(r'''
+@ShouldGenerate(
+  r'''
 CtorParamJsonKey _$CtorParamJsonKeyFromJson(Map<String, dynamic> json) =>
     CtorParamJsonKey(
       attributeOne: json['first'] as String,
@@ -15,11 +16,13 @@ Map<String, dynamic> _$CtorParamJsonKeyToJson(CtorParamJsonKey instance) =>
       'first': instance.attributeOne,
       'second': instance.attributeTwo,
     };
-''', expectedLogItems: [
-  'Field `attributeOne` has conflicting `JsonKey.name` annotations: both '
-  'constructor parameter and class field have this annotation. Using '
-  'constructor parameter value.',
-])
+''',
+  expectedLogItems: [
+    'Field `attributeOne` has conflicting `JsonKey.name` annotations: both '
+        'constructor parameter and class field have this annotation. Using '
+        'constructor parameter value.',
+  ],
+)
 @JsonSerializable()
 class CtorParamJsonKey {
   CtorParamJsonKey({


### PR DESCRIPTION
About https://github.com/google/json_serializable.dart/issues/1437

Allow `@JsonKey` to be used on constructor parameters, where the `@JsonKey` properties will override the corresponding field properties.