### PR TITLE
Fix bug running code generation for classes inheriting from `ListBase`

### DIFF
--- a/json_serializable/lib/src/field_helpers.dart
+++ b/json_serializable/lib/src/field_helpers.dart
@@ -58,9 +58,9 @@ class _FieldSet implements Comparable<_FieldSet> {
     /// preference for the getter if it's defined.
     int offsetFor(FieldElement2 e) {
       if (e.isSynthetic) {
-        return (e.getter2 ?? e.setter2)!.firstFragment.nameOffset2!;
+        return (e.getter2 ?? e.setter2)!.firstFragment.nameOffset2 ?? 0;
       }
-      return e.firstFragment.nameOffset2!;
+      return e.firstFragment.nameOffset2 ?? 0;
     }
 
     return offsetFor(a).compareTo(offsetFor(b));

--- a/json_serializable/test/integration/json_test_example.dart
+++ b/json_serializable/test/integration/json_test_example.dart
@@ -266,3 +266,34 @@ class RegressionTestIssue1210 with RegressionTestIssue1210Mixin {
 
   Map<String, dynamic> toJson() => _$RegressionTestIssue1210ToJson(this);
 }
+
+@JsonSerializable()
+class CustomList extends ListBase<String> {
+  // Regression test for issue:
+  // https://github.com/google/json_serializable.dart/issues/1512
+
+  final List<String> _innerList = [];
+
+  CustomList();
+
+  @override
+  int get length => _innerList.length;
+
+  @override
+  set length(int newLength) {
+    _innerList.length = newLength;
+  }
+
+  @override
+  String operator [](int index) => _innerList[index];
+
+  @override
+  void operator []=(int index, String value) {
+    _innerList[index] = value;
+  }
+
+  factory CustomList.fromJson(Map<String, dynamic> json) =>
+      _$CustomListFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CustomListToJson(this);
+}

--- a/json_serializable/test/integration/json_test_example.g.dart
+++ b/json_serializable/test/integration/json_test_example.g.dart
@@ -229,3 +229,15 @@ RegressionTestIssue1210 _$RegressionTestIssue1210FromJson(
 Map<String, dynamic> _$RegressionTestIssue1210ToJson(
   RegressionTestIssue1210 instance,
 ) => <String, dynamic>{'field': instance.field};
+
+CustomList _$CustomListFromJson(Map<String, dynamic> json) => CustomList()
+  ..first = json['first'] as String
+  ..last = json['last'] as String
+  ..length = (json['length'] as num).toInt();
+
+Map<String, dynamic> _$CustomListToJson(CustomList instance) =>
+    <String, dynamic>{
+      'first': instance.first,
+      'last': instance.last,
+      'length': instance.length,
+    };

--- a/json_serializable/test/integration/json_test_example.g_any_map.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.dart
@@ -266,3 +266,34 @@ class RegressionTestIssue1210 with RegressionTestIssue1210Mixin {
 
   Map<String, dynamic> toJson() => _$RegressionTestIssue1210ToJson(this);
 }
+
+@JsonSerializable(anyMap: true)
+class CustomList extends ListBase<String> {
+  // Regression test for issue:
+  // https://github.com/google/json_serializable.dart/issues/1512
+
+  final List<String> _innerList = [];
+
+  CustomList();
+
+  @override
+  int get length => _innerList.length;
+
+  @override
+  set length(int newLength) {
+    _innerList.length = newLength;
+  }
+
+  @override
+  String operator [](int index) => _innerList[index];
+
+  @override
+  void operator []=(int index, String value) {
+    _innerList[index] = value;
+  }
+
+  factory CustomList.fromJson(Map<String, dynamic> json) =>
+      _$CustomListFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CustomListToJson(this);
+}

--- a/json_serializable/test/integration/json_test_example.g_any_map.g.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.g.dart
@@ -227,3 +227,15 @@ RegressionTestIssue1210 _$RegressionTestIssue1210FromJson(Map json) =>
 Map<String, dynamic> _$RegressionTestIssue1210ToJson(
   RegressionTestIssue1210 instance,
 ) => <String, dynamic>{'field': instance.field};
+
+CustomList _$CustomListFromJson(Map json) => CustomList()
+  ..first = json['first'] as String
+  ..last = json['last'] as String
+  ..length = (json['length'] as num).toInt();
+
+Map<String, dynamic> _$CustomListToJson(CustomList instance) =>
+    <String, dynamic>{
+      'first': instance.first,
+      'last': instance.last,
+      'length': instance.length,
+    };


### PR DESCRIPTION
This is an attempt to fix #1512.

As reported in this issue, the error
> Null check operator used on a null value 

occurs when trying to generate the code for a class inheriting from for example `ListBase`.

With this fix all tests including the newly introduced regression test for this issue succeed. However I am not very sure if this is the most elegant solution. It seems like the fields that triggered the error are later filtered out nevertheless, for which reason the offset should not matter in those cases.