### PR TITLE
Add `dart format off` and `dart format on` comments

### DIFF
--- a/example/lib/example.g.dart
+++ b/example/lib/example.g.dart
@@ -2,6 +2,8 @@
 
 part of 'example.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -86,3 +88,5 @@ final _$glossaryDataJsonLiteral = {
     },
   },
 };
+
+// dart format on

--- a/example/lib/generic_response_class_example.g.dart
+++ b/example/lib/generic_response_class_example.g.dart
@@ -2,6 +2,8 @@
 
 part of 'generic_response_class_example.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -31,3 +33,5 @@ Comment _$CommentFromJson(Map<String, dynamic> json) => Comment(
   id: (json['id'] as num?)?.toInt(),
   content: json['content'] as String?,
 );
+
+// dart format on

--- a/example/lib/json_converter_example.g.dart
+++ b/example/lib/json_converter_example.g.dart
@@ -2,6 +2,8 @@
 
 part of 'json_converter_example.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -41,3 +43,5 @@ CustomResult _$CustomResultFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$CustomResultToJson(CustomResult instance) =>
     <String, dynamic>{'name': instance.name, 'size': instance.size};
+
+// dart format on

--- a/example/lib/nested_values_example.g.dart
+++ b/example/lib/nested_values_example.g.dart
@@ -2,6 +2,8 @@
 
 part of 'nested_values_example.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -17,3 +19,5 @@ Map<String, dynamic> _$NestedValueExampleToJson(NestedValueExample instance) =>
     <String, dynamic>{
       'root_items': const _NestedListConverter().toJson(instance.nestedValues),
     };
+
+// dart format on

--- a/example/lib/tuple_example.g.dart
+++ b/example/lib/tuple_example.g.dart
@@ -2,6 +2,8 @@
 
 part of 'tuple_example.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -46,3 +48,5 @@ Map<String, dynamic> _$ConcreteClassToJson(ConcreteClass instance) =>
         (value) => value.toString(),
       ),
     };
+
+// dart format on

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Require `dart_style: ^3.0.0`
 - Require `meta: ^1.15.0`
 - Require `source_helper: ^1.3.6`
+- Support `page_width` other than 80.
 
 ## 6.10.0
 

--- a/json_serializable/example/example.g.dart
+++ b/json_serializable/example/example.g.dart
@@ -4,6 +4,8 @@
 
 part of 'example.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -21,3 +23,5 @@ Map<String, dynamic> _$PersonToJson(Person instance) => <String, dynamic>{
   'lastName': instance.lastName,
   'dateOfBirth': instance.dateOfBirth?.toIso8601String(),
 };
+
+// dart format on

--- a/json_serializable/lib/src/json_part_builder.dart
+++ b/json_serializable/lib/src/json_part_builder.dart
@@ -111,4 +111,4 @@ ArgumentError _argError(Object value) => ArgumentError(
 );
 
 String defaultFormatOutput(String code, Version languageVersion) =>
-    DartFormatter(languageVersion: languageVersion).format(code);
+    '// dart format off\n\n${DartFormatter(languageVersion: languageVersion).format(code)}\n// dart format on\n';

--- a/json_serializable/test/default_value/default_value.g.dart
+++ b/json_serializable/test/default_value/default_value.g.dart
@@ -4,6 +4,8 @@
 
 part of 'default_value.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -99,3 +101,5 @@ const _$GreekEnumMap = {
   Greek.gamma: 'gamma',
   Greek.delta: 'delta',
 };
+
+// dart format on

--- a/json_serializable/test/default_value/default_value.g_any_map__checked.g.dart
+++ b/json_serializable/test/default_value/default_value.g_any_map__checked.g.dart
@@ -4,6 +4,8 @@
 
 part of 'default_value.g_any_map__checked.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -135,3 +137,5 @@ const _$GreekEnumMap = {
   Greek.gamma: 'gamma',
   Greek.delta: 'delta',
 };
+
+// dart format on

--- a/json_serializable/test/default_value/implicit_default_value.g.dart
+++ b/json_serializable/test/default_value/implicit_default_value.g.dart
@@ -4,6 +4,8 @@
 
 part of 'implicit_default_value.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -108,3 +110,5 @@ const _$GreekEnumMap = {
   Greek.gamma: 'gamma',
   Greek.delta: 'delta',
 };
+
+// dart format on

--- a/json_serializable/test/field_matrix_test.field_matrix.g.dart
+++ b/json_serializable/test/field_matrix_test.field_matrix.g.dart
@@ -4,6 +4,8 @@
 
 part of 'field_matrix_test.field_matrix.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -232,3 +234,5 @@ ToJsonFalseFromJsonFalsePrivate _$ToJsonFalseFromJsonFalsePrivateFromJson(
 Map<String, dynamic> _$ToJsonFalseFromJsonFalsePrivateToJson(
   ToJsonFalseFromJsonFalsePrivate instance,
 ) => <String, dynamic>{'aField': instance.aField, 'zField': instance.zField};
+
+// dart format on

--- a/json_serializable/test/generic_files/generic_argument_factories.g.dart
+++ b/json_serializable/test/generic_files/generic_argument_factories.g.dart
@@ -4,6 +4,8 @@
 
 part of 'generic_argument_factories.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -59,3 +61,5 @@ Map<String, dynamic> _$ConcreteClassToJson(ConcreteClass instance) =>
         (value) => value?.toString(),
       ),
     };
+
+// dart format on

--- a/json_serializable/test/generic_files/generic_argument_factories_nullable.g.dart
+++ b/json_serializable/test/generic_files/generic_argument_factories_nullable.g.dart
@@ -4,6 +4,8 @@
 
 part of 'generic_argument_factories_nullable.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -80,3 +82,5 @@ Map<String, dynamic> _$ConcreteClassNullableToJson(
     (value) => value?.toString(),
   ),
 };
+
+// dart format on

--- a/json_serializable/test/generic_files/generic_class.g.dart
+++ b/json_serializable/test/generic_files/generic_class.g.dart
@@ -4,6 +4,8 @@
 
 part of 'generic_class.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -133,3 +135,5 @@ Map<String, dynamic> _$Issue1047ClassToJson<T>(
   Issue1047Class<T> instance,
   Object? Function(T value) toJsonT,
 ) => <String, dynamic>{'node': toJsonT(instance.node)};
+
+// dart format on

--- a/json_serializable/test/integration/converter_examples.g.dart
+++ b/json_serializable/test/integration/converter_examples.g.dart
@@ -4,6 +4,8 @@
 
 part of 'converter_examples.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -74,3 +76,5 @@ Json? _$JsonConverterToJson<Json, Value>(
   Value? value,
   Json? Function(Value value) toJson,
 ) => value == null ? null : toJson(value);
+
+// dart format on

--- a/json_serializable/test/integration/create_per_field_to_json_example.g.dart
+++ b/json_serializable/test/integration/create_per_field_to_json_example.g.dart
@@ -4,6 +4,8 @@
 
 part of 'create_per_field_to_json_example.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -99,3 +101,5 @@ abstract class _$PrivateModelPerFieldToJson {
 
 Map<String, dynamic> _$PrivateModelToJson(_PrivateModel instance) =>
     <String, dynamic>{'full-name': instance.fullName};
+
+// dart format on

--- a/json_serializable/test/integration/field_map_example.g.dart
+++ b/json_serializable/test/integration/field_map_example.g.dart
@@ -4,6 +4,8 @@
 
 part of 'field_map_example.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -27,3 +29,5 @@ const _$PrivateModelFieldMap = <String, String>{'fullName': 'full-name'};
 
 Map<String, dynamic> _$PrivateModelToJson(_PrivateModel instance) =>
     <String, dynamic>{'full-name': instance.fullName};
+
+// dart format on

--- a/json_serializable/test/integration/json_enum_example.g.dart
+++ b/json_serializable/test/integration/json_enum_example.g.dart
@@ -4,6 +4,8 @@
 
 part of 'json_enum_example.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -88,3 +90,5 @@ const _$EnumValueFieldIndexEnumMap = {
   EnumValueFieldIndex.weird: 701,
   EnumValueFieldIndex.oneMore: 2,
 };
+
+// dart format on

--- a/json_serializable/test/integration/json_keys_example.g.dart
+++ b/json_serializable/test/integration/json_keys_example.g.dart
@@ -4,6 +4,8 @@
 
 part of 'json_keys_example.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -22,3 +24,5 @@ Map<String, dynamic> _$ModelToJson(Model instance) => <String, dynamic>{
   'first-name': instance.firstName,
   'LAST_NAME': instance.lastName,
 };
+
+// dart format on

--- a/json_serializable/test/integration/json_test_example.g.dart
+++ b/json_serializable/test/integration/json_test_example.g.dart
@@ -4,6 +4,8 @@
 
 part of 'json_test_example.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -241,3 +243,5 @@ Map<String, dynamic> _$CustomListToJson(CustomList instance) =>
       'last': instance.last,
       'length': instance.length,
     };
+
+// dart format on

--- a/json_serializable/test/integration/json_test_example.g_any_map.g.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.g.dart
@@ -4,6 +4,8 @@
 
 part of 'json_test_example.g_any_map.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -239,3 +241,5 @@ Map<String, dynamic> _$CustomListToJson(CustomList instance) =>
       'last': instance.last,
       'length': instance.length,
     };
+
+// dart format on

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
@@ -4,6 +4,8 @@
 
 part of 'kitchen_sink.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -310,3 +312,5 @@ Map<String, dynamic> _$JsonConverterGenericToJson<S, T, U>(
     (k, e) => MapEntry(k, GenericConverter<U>().toJson(e)),
   ),
 };
+
+// dart format on

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map.g.dart
@@ -4,6 +4,8 @@
 
 part of 'kitchen_sink.g_any_map.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -307,3 +309,5 @@ Map<String, dynamic> _$JsonConverterGenericToJson<S, T, U>(
     (k, e) => MapEntry(k, GenericConverter<U>().toJson(e)),
   ),
 };
+
+// dart format on

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map__checked.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map__checked.g.dart
@@ -4,6 +4,8 @@
 
 part of 'kitchen_sink.g_any_map__checked.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -428,3 +430,5 @@ Map<String, dynamic> _$JsonConverterGenericToJson<S, T, U>(
     (k, e) => MapEntry(k, GenericConverter<U>().toJson(e)),
   ),
 };
+
+// dart format on

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_exclude_null.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_exclude_null.g.dart
@@ -4,6 +4,8 @@
 
 part of 'kitchen_sink.g_exclude_null.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -310,3 +312,5 @@ Map<String, dynamic> _$JsonConverterGenericToJson<S, T, U>(
     (k, e) => MapEntry(k, GenericConverter<U>().toJson(e)),
   ),
 };
+
+// dart format on

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_explicit_to_json.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_explicit_to_json.g.dart
@@ -4,6 +4,8 @@
 
 part of 'kitchen_sink.g_explicit_to_json.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -314,3 +316,5 @@ Map<String, dynamic> _$JsonConverterGenericToJson<S, T, U>(
     (k, e) => MapEntry(k, GenericConverter<U>().toJson(e)),
   ),
 };
+
+// dart format on

--- a/json_serializable/test/kitchen_sink/simple_object.g.dart
+++ b/json_serializable/test/kitchen_sink/simple_object.g.dart
@@ -4,6 +4,8 @@
 
 part of 'simple_object.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -13,3 +15,5 @@ SimpleObject _$SimpleObjectFromJson(Map json) =>
 
 Map<String, dynamic> _$SimpleObjectToJson(SimpleObject instance) =>
     <String, dynamic>{'value': instance.value};
+
+// dart format on

--- a/json_serializable/test/kitchen_sink/strict_keys_object.g.dart
+++ b/json_serializable/test/kitchen_sink/strict_keys_object.g.dart
@@ -4,6 +4,8 @@
 
 part of 'strict_keys_object.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -25,3 +27,5 @@ Map<String, dynamic> _$StrictKeysObjectToJson(StrictKeysObject instance) =>
       'value': instance.value,
       'custom_field': instance.customField,
     };
+
+// dart format on

--- a/json_serializable/test/literal/json_literal.g.dart
+++ b/json_serializable/test/literal/json_literal.g.dart
@@ -4,6 +4,8 @@
 
 part of 'json_literal.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonLiteralGenerator
 // **************************************************************************
@@ -603,3 +605,5 @@ const _$naughtyStringsJsonLiteral = [
   'The quic\b\b\b\b\b\bk brown fo\x07\x07\x07\x07\x07\x07\x07\x07\x07\x07\x07x... [Beeeep]',
   'Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗',
 ];
+
+// dart format on

--- a/json_serializable/test/supported_types/input.g.dart
+++ b/json_serializable/test/supported_types/input.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -16,3 +18,5 @@ Map<String, dynamic> _$SimpleClassToJson(SimpleClass instance) =>
       'value': instance.value,
       'withDefault': instance.withDefault,
     };
+
+// dart format on

--- a/json_serializable/test/supported_types/input.type_bigint.g.dart
+++ b/json_serializable/test/supported_types/input.type_bigint.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.type_bigint.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -35,3 +37,5 @@ Map<String, dynamic> _$SimpleClassNullableToJson(
   'value': instance.value?.toString(),
   'withDefault': instance.withDefault?.toString(),
 };
+
+// dart format on

--- a/json_serializable/test/supported_types/input.type_bool.g.dart
+++ b/json_serializable/test/supported_types/input.type_bool.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.type_bool.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -29,3 +31,5 @@ Map<String, dynamic> _$SimpleClassNullableToJson(
   'value': instance.value,
   'withDefault': instance.withDefault,
 };
+
+// dart format on

--- a/json_serializable/test/supported_types/input.type_datetime.g.dart
+++ b/json_serializable/test/supported_types/input.type_datetime.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.type_datetime.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -35,3 +37,5 @@ Map<String, dynamic> _$SimpleClassNullableToJson(
   'value': instance.value?.toIso8601String(),
   'withDefault': instance.withDefault?.toIso8601String(),
 };
+
+// dart format on

--- a/json_serializable/test/supported_types/input.type_double.g.dart
+++ b/json_serializable/test/supported_types/input.type_double.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.type_double.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -31,3 +33,5 @@ Map<String, dynamic> _$SimpleClassNullableToJson(
   'value': instance.value,
   'withDefault': instance.withDefault,
 };
+
+// dart format on

--- a/json_serializable/test/supported_types/input.type_duration.g.dart
+++ b/json_serializable/test/supported_types/input.type_duration.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.type_duration.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -24,3 +26,5 @@ SimpleClassNullable _$SimpleClassNullableFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$SimpleClassNullableToJson(
   SimpleClassNullable instance,
 ) => <String, dynamic>{'value': instance.value?.inMicroseconds};
+
+// dart format on

--- a/json_serializable/test/supported_types/input.type_enumtype.g.dart
+++ b/json_serializable/test/supported_types/input.type_enumtype.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.type_enumtype.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -39,3 +41,5 @@ Map<String, dynamic> _$SimpleClassNullableToJson(
   'value': _$EnumTypeEnumMap[instance.value],
   'withDefault': _$EnumTypeEnumMap[instance.withDefault],
 };
+
+// dart format on

--- a/json_serializable/test/supported_types/input.type_int.g.dart
+++ b/json_serializable/test/supported_types/input.type_int.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.type_int.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -31,3 +33,5 @@ Map<String, dynamic> _$SimpleClassNullableToJson(
   'value': instance.value,
   'withDefault': instance.withDefault,
 };
+
+// dart format on

--- a/json_serializable/test/supported_types/input.type_iterable.g.dart
+++ b/json_serializable/test/supported_types/input.type_iterable.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.type_iterable.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -660,3 +662,5 @@ Map<String, dynamic> _$SimpleClassNullableOfUriNullableToJson(
 ) => <String, dynamic>{
   'value': instance.value?.map((e) => e?.toString()).toList(),
 };
+
+// dart format on

--- a/json_serializable/test/supported_types/input.type_list.g.dart
+++ b/json_serializable/test/supported_types/input.type_list.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.type_list.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -691,3 +693,5 @@ Map<String, dynamic> _$SimpleClassNullableOfUriNullableToJson(
 ) => <String, dynamic>{
   'value': instance.value?.map((e) => e?.toString()).toList(),
 };
+
+// dart format on

--- a/json_serializable/test/supported_types/input.type_map.g.dart
+++ b/json_serializable/test/supported_types/input.type_map.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.type_map.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -6510,3 +6512,5 @@ Map<String, dynamic> _$SimpleClassNullableOfUriToUriNullableToJson(
 ) => <String, dynamic>{
   'value': instance.value?.map((k, e) => MapEntry(k.toString(), e?.toString())),
 };
+
+// dart format on

--- a/json_serializable/test/supported_types/input.type_num.g.dart
+++ b/json_serializable/test/supported_types/input.type_num.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.type_num.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -29,3 +31,5 @@ Map<String, dynamic> _$SimpleClassNullableToJson(
   'value': instance.value,
   'withDefault': instance.withDefault,
 };
+
+// dart format on

--- a/json_serializable/test/supported_types/input.type_object.g.dart
+++ b/json_serializable/test/supported_types/input.type_object.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.type_object.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -28,3 +30,5 @@ Map<String, dynamic> _$SimpleClassNullableToJson(
   'value': instance.value,
   'withDefault': instance.withDefault,
 };
+
+// dart format on

--- a/json_serializable/test/supported_types/input.type_record.g.dart
+++ b/json_serializable/test/supported_types/input.type_record.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.type_record.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -1247,3 +1249,5 @@ Map<String, dynamic> _$SimpleClassNullableOfUriNullableToJson(
           'named': instance.value!.named?.toString(),
         },
 };
+
+// dart format on

--- a/json_serializable/test/supported_types/input.type_set.g.dart
+++ b/json_serializable/test/supported_types/input.type_set.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.type_set.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -690,3 +692,5 @@ Map<String, dynamic> _$SimpleClassNullableOfUriNullableToJson(
 ) => <String, dynamic>{
   'value': instance.value?.map((e) => e?.toString()).toList(),
 };
+
+// dart format on

--- a/json_serializable/test/supported_types/input.type_string.g.dart
+++ b/json_serializable/test/supported_types/input.type_string.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.type_string.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -31,3 +33,5 @@ Map<String, dynamic> _$SimpleClassNullableToJson(
   'value': instance.value,
   'withDefault': instance.withDefault,
 };
+
+// dart format on

--- a/json_serializable/test/supported_types/input.type_uri.g.dart
+++ b/json_serializable/test/supported_types/input.type_uri.g.dart
@@ -4,6 +4,8 @@
 
 part of 'input.type_uri.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -35,3 +37,5 @@ Map<String, dynamic> _$SimpleClassNullableToJson(
   'value': instance.value?.toString(),
   'withDefault': instance.withDefault?.toString(),
 };
+
+// dart format on

--- a/json_serializable/tool/readme/readme_examples.g.dart
+++ b/json_serializable/tool/readme/readme_examples.g.dart
@@ -4,6 +4,8 @@
 
 part of 'readme_examples.dart';
 
+// dart format off
+
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
@@ -29,3 +31,5 @@ Sample4 _$Sample4FromJson(Map<String, dynamic> json) => Sample4(
 Map<String, dynamic> _$Sample4ToJson(Sample4 instance) => <String, dynamic>{
   'value': const EpochDateTimeConverter().toJson(instance.value),
 };
+
+// dart format on


### PR DESCRIPTION
close #1518 

Added the comments `// dart format off` and `// dart format on` to the code generated using `defaultFormatOutput`.
With this fix, additional formatting will no longer be applied to the generated code even if the project's `page_width` setting is not 80.

ref https://github.com/dart-lang/build/issues/3812#issuecomment-2641576908
ref https://github.com/dart-lang/build/issues/3887#issuecomment-2687338332