### PR TITLE
Declare to support build and source_gen 4

### DIFF
--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -17,7 +17,7 @@ resolution: workspace
 dependencies:
   analyzer: '>=7.4.0 <9.0.0'
   async: ^2.10.0
-  build: ^3.0.0
+  build: '>=3.0.0 <5.0.0'
   build_config: ^1.1.0
   dart_style: ^3.0.0
 
@@ -28,7 +28,7 @@ dependencies:
   path: ^1.9.0
   pub_semver: ^2.1.4
   pubspec_parse: ^1.0.0
-  source_gen: ^3.1.0
+  source_gen: '>=3.1.0 <5.0.0'
   source_helper: ^1.3.6
 
 dev_dependencies:


### PR DESCRIPTION
This expands the dependency range on `build` and `source_gen` to include the latest major version of those packages.

Note: Resolving to those versions is unsupported because `source_gen_test` does not support the latest package version yet (https://github.com/kevmoo/source_gen_test/pull/92).
I ran tests with `dependency_overrides`, and they failed due to issues in `source_gen_test`.  There are no compilation issues within `json_serializable` though, so things should work. This would help other packages upgrade to build version 4.