### PR TITLE
Skip warning about duplicate annotations if the values match.

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Allow `run_only_if_triggered` to be specified in `build.yaml` to turn on the
   `build_runner` triggers heuristic.
+- Skip warning about annotations on both constructor and field if the values
+  match.
 
 ## 6.11.1
 

--- a/json_serializable/lib/src/json_key_utils.dart
+++ b/json_serializable/lib/src/json_key_utils.dart
@@ -36,7 +36,9 @@ KeyConfig _from(FieldElement2 element, ClassConfig classAnnotation) {
     if (ctorObj != null && !ctorObj.isNull) {
       final ctorReadResult = ctorObj.read(field);
       if (!ctorReadResult.isNull) {
-        if (!obj.isNull && !obj.read(field).isNull) {
+        final fieldReadResult = obj.isNull ? null : obj.read(field);
+        if (fieldReadResult != null &&
+            fieldReadResult.objectValue != ctorReadResult.objectValue) {
           log.warning(
             'Field `${element.name3}` has conflicting `JsonKey.$field` '
             'annotations: both constructor parameter and class field have '

--- a/json_serializable/test/src/extends_jsonkey_override.dart
+++ b/json_serializable/test/src/extends_jsonkey_override.dart
@@ -32,10 +32,14 @@ class CtorParamJsonKey {
 
   @JsonKey(name: 'fake_first')
   final String attributeOne;
+
+  // Duplicate annotation with exact same value does not give a warning.
+  @JsonKey(name: 'second')
   final String attributeTwo;
 }
 
-@ShouldGenerate(r'''
+@ShouldGenerate(
+  r'''
 CtorParamJsonKeyWithExtends _$CtorParamJsonKeyWithExtendsFromJson(
   Map<String, dynamic> json,
 ) => CtorParamJsonKeyWithExtends(
@@ -49,7 +53,13 @@ Map<String, dynamic> _$CtorParamJsonKeyWithExtendsToJson(
   'fake_first': instance.attributeOne,
   'two': instance.attributeTwo,
 };
-''')
+''',
+  expectedLogItems: [
+    'Field `attributeTwo` has conflicting `JsonKey.name` annotations: both '
+        'constructor parameter and class field have this annotation. Using '
+        'constructor parameter value.',
+  ],
+)
 @JsonSerializable()
 class CtorParamJsonKeyWithExtends extends CtorParamJsonKey {
   CtorParamJsonKeyWithExtends({


### PR DESCRIPTION
Fix https://github.com/rrousselGit/freezed/issues/1289

Freezed copies annotations onto generated code, which triggers the json_serializable warning.

Fix by skipping warning if the value matches.

I'm not 100% sure about the implementation, I did add a test, but please do check it makes sense :)