### PR TITLE
Add enum support to createJsonSchema

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Support `JsonKey.explicitJsonNullWhenNonNullField` for PATCH-style tri-state
   JSON fields: distinguish omitted keys from explicit `null` in `fromJson` and
   emit explicit JSON `null` in `toJson` when the Dart field is non-null.
+- Fix `createJsonSchema` to emit an `enum` constraint (and `default`) for
+  enum-typed fields, respecting `@JsonValue` and `JsonEnum.valueField`.
+  ([#1577](https://github.com/google/json_serializable.dart/issues/1577))
 - Require `json_annotation: '>=4.12.0 <4.13.0'`
 
 ## 6.13.2

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,11 +1,14 @@
+## 6.15.0-wip
+
+- Fix `createJsonSchema` to emit an `enum` constraint (and `default`) for
+  enum-typed fields, respecting `@JsonValue` and `JsonEnum.valueField`.
+  ([#1577](https://github.com/google/json_serializable.dart/issues/1577))
+
 ## 6.14.0
 
 - Support `JsonKey.explicitJsonNullWhenNonNullField` for PATCH-style tri-state
   JSON fields: distinguish omitted keys from explicit `null` in `fromJson` and
   emit explicit JSON `null` in `toJson` when the Dart field is non-null.
-- Fix `createJsonSchema` to emit an `enum` constraint (and `default`) for
-  enum-typed fields, respecting `@JsonValue` and `JsonEnum.valueField`.
-  ([#1577](https://github.com/google/json_serializable.dart/issues/1577))
 - Require `json_annotation: '>=4.12.0 <4.13.0'`
 
 ## 6.13.2

--- a/json_serializable/lib/src/enum_utils.dart
+++ b/json_serializable/lib/src/enum_utils.dart
@@ -53,6 +53,16 @@ String? enumValueMapFromType(
   return 'const ${constMapName(targetType)} = {\n$items\n};';
 }
 
+/// If [targetType] is an enum, returns the values used to encode its constants
+/// in JSON, in declaration order.
+///
+/// Otherwise, `null`.
+List<Object?>? enumEncodedValues(DartType targetType) {
+  final enumMap = _enumMap(targetType);
+  if (enumMap == null) return null;
+  return enumMap.values.toList(growable: false);
+}
+
 Map<FieldElement, Object?>? _enumMap(
   DartType targetType, {
   bool nullWithNoAnnotation = false,

--- a/json_serializable/lib/src/schema_helper.dart
+++ b/json_serializable/lib/src/schema_helper.dart
@@ -9,6 +9,7 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:source_helper/source_helper.dart';
 
+import 'enum_utils.dart';
 import 'field_helpers.dart';
 import 'helper_core.dart';
 import 'json_key_utils.dart';
@@ -239,6 +240,11 @@ Map<String, dynamic> _getPropertySchema(
     };
   }
 
+  final enumValues = enumEncodedValues(type);
+  if (enumValues != null) {
+    return {'enum': enumValues};
+  }
+
   if (type is InterfaceType && !type.isDartCoreObject) {
     return _generateComplexTypeSchema(
       type,
@@ -320,8 +326,15 @@ Object? _defaultValue(DartObject defaultValue, DartType type) => switch (type) {
     defaultValue.toListValue(),
   _ when coreMapTypeChecker.isAssignableFromType(type) =>
     defaultValue.toMapValue(),
+  _ when type.isEnum => _enumDefaultValue(defaultValue, type),
   _ => _noMatch,
 };
+
+Object? _enumDefaultValue(DartObject defaultValue, DartType type) {
+  final values = enumEncodedValues(type);
+  if (values == null) return _noMatch;
+  return enumValueForDartObject<Object?>(defaultValue, values, (v) => '$v');
+}
 
 /// Sentinel value used to indicate that no default value could be determined.
 final _noMatch = Object();

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 6.14.0
+version: 6.15.0-wip
 description: >-
   Automatically generate code for converting to and from JSON by annotating
   Dart classes.

--- a/json_serializable/test/integration/schema_example.dart
+++ b/json_serializable/test/integration/schema_example.dart
@@ -113,3 +113,21 @@ final class ComprehensiveNested {
 
   static const schema = _$ComprehensiveNestedJsonSchema;
 }
+
+@JsonEnum()
+enum Season { spring, summer, autumn, winter }
+
+@JsonSerializable(createJsonSchema: true)
+final class SchemaEnumExample {
+  final Season season;
+  final List<Season> seasons;
+
+  SchemaEnumExample(this.season, this.seasons);
+
+  factory SchemaEnumExample.fromJson(Map<String, dynamic> json) =>
+      _$SchemaEnumExampleFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SchemaEnumExampleToJson(this);
+
+  static const schema = _$SchemaEnumExampleJsonSchema;
+}

--- a/json_serializable/test/integration/schema_example.g.dart
+++ b/json_serializable/test/integration/schema_example.g.dart
@@ -172,3 +172,41 @@ const _$ComprehensiveNestedJsonSchema = {
   },
   'required': ['getterIncluded'],
 };
+
+SchemaEnumExample _$SchemaEnumExampleFromJson(Map<String, dynamic> json) =>
+    SchemaEnumExample(
+      $enumDecode(_$SeasonEnumMap, json['season']),
+      (json['seasons'] as List<dynamic>)
+          .map((e) => $enumDecode(_$SeasonEnumMap, e))
+          .toList(),
+    );
+
+Map<String, dynamic> _$SchemaEnumExampleToJson(SchemaEnumExample instance) =>
+    <String, dynamic>{
+      'season': _$SeasonEnumMap[instance.season]!,
+      'seasons': instance.seasons.map((e) => _$SeasonEnumMap[e]!).toList(),
+    };
+
+const _$SchemaEnumExampleJsonSchema = {
+  r'$schema': 'https://json-schema.org/draft/2020-12/schema',
+  'type': 'object',
+  'properties': {
+    'season': {
+      'enum': ['spring', 'summer', 'autumn', 'winter'],
+    },
+    'seasons': {
+      'type': 'array',
+      'items': {
+        'enum': ['spring', 'summer', 'autumn', 'winter'],
+      },
+    },
+  },
+  'required': ['season', 'seasons'],
+};
+
+const _$SeasonEnumMap = {
+  Season.spring: 'spring',
+  Season.summer: 'summer',
+  Season.autumn: 'autumn',
+  Season.winter: 'winter',
+};

--- a/json_serializable/test/integration/schema_test.dart
+++ b/json_serializable/test/integration/schema_test.dart
@@ -110,4 +110,43 @@ void main() {
       );
     });
   });
+
+  group('SchemaEnumExample', () {
+    late JsonSchema schema;
+
+    setUpAll(() {
+      schema = JsonSchema.create(SchemaEnumExample.schema);
+    });
+
+    test('valid instance', () {
+      final instance = SchemaEnumExample(Season.summer, [
+        Season.spring,
+        Season.winter,
+      ]);
+
+      final json = jsonDecode(jsonEncode(instance));
+      final validation = schema.validate(json);
+      expect(validation.isValid, isTrue, reason: validation.errors.toString());
+    });
+
+    test('invalid instance - value not in enum', () {
+      final json = <String, dynamic>{
+        'season': 'fall', // not a valid Season
+        'seasons': <dynamic>['spring'],
+      };
+
+      final validation = schema.validate(json);
+      expect(validation.isValid, isFalse);
+    });
+
+    test('invalid instance - bad value in enum list', () {
+      final json = <String, dynamic>{
+        'season': 'summer',
+        'seasons': <dynamic>['spring', 'fall'],
+      };
+
+      final validation = schema.validate(json);
+      expect(validation.isValid, isFalse);
+    });
+  });
 }

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -196,4 +196,5 @@ const _expectedSchemaTests = {
   'JsonSchemaGetterTest',
   'JsonSchemaRecursiveListTest',
   'JsonSchemaRecursiveListIssue',
+  'JsonSchemaEnumTest',
 };

--- a/json_serializable/test/src/_json_schema_test_input.dart
+++ b/json_serializable/test/src/_json_schema_test_input.dart
@@ -290,3 +290,80 @@ class JsonSchemaRecursiveListIssueA {
 
   JsonSchemaRecursiveListIssueA(this.children);
 }
+
+enum JsonSchemaCategory { fruit, vegetable, grain }
+
+enum JsonSchemaPriority {
+  @JsonValue(1)
+  low,
+  @JsonValue(2)
+  medium,
+  @JsonValue(3)
+  high,
+}
+
+enum JsonSchemaNullableValue {
+  @JsonValue(null)
+  unknown,
+  @JsonValue('known')
+  known,
+}
+
+@ShouldGenerate(r'''
+const _$JsonSchemaEnumTestJsonSchema = {
+  r'$schema': 'https://json-schema.org/draft/2020-12/schema',
+  'type': 'object',
+  'properties': {
+    'category': {
+      'enum': ['fruit', 'vegetable', 'grain'],
+    },
+    'categories': {
+      'type': 'array',
+      'items': {
+        'enum': ['fruit', 'vegetable', 'grain'],
+      },
+    },
+    'priority': {
+      'enum': [1, 2, 3],
+      'description': 'Encoded with `@JsonValue` overrides',
+    },
+    'nullableValue': {
+      'enum': [null, 'known'],
+      'description': '`@JsonValue(null)` is a valid member',
+    },
+    'priorityWithDefault': {
+      'enum': [1, 2, 3],
+      'description': 'Default uses the encoded value, respecting `@JsonValue`',
+      'default': 2,
+    },
+  },
+  'required': ['category', 'categories', 'priority', 'nullableValue'],
+};
+''')
+@JsonSerializable(
+  createJsonSchema: true,
+  createFactory: false,
+  createToJson: false,
+)
+class JsonSchemaEnumTest {
+  final JsonSchemaCategory category;
+  final List<JsonSchemaCategory> categories;
+
+  /// Encoded with `@JsonValue` overrides
+  final JsonSchemaPriority priority;
+
+  /// `@JsonValue(null)` is a valid member
+  final JsonSchemaNullableValue nullableValue;
+
+  /// Default uses the encoded value, respecting `@JsonValue`
+  @JsonKey(defaultValue: JsonSchemaPriority.medium)
+  final JsonSchemaPriority priorityWithDefault;
+
+  JsonSchemaEnumTest(
+    this.category,
+    this.categories,
+    this.priority,
+    this.nullableValue,
+    this.priorityWithDefault,
+  );
+}


### PR DESCRIPTION
Adds enum support to createJsonSchema generation. 

Enum-typed fields in `createJsonSchema` were emitting `{"type": "object"}`.
This emits a JSON Schema `enum` constraint (and `default`) using the encoded
values, reusing the existing enum-encoding path so `@JsonValue` and
`JsonEnum.valueField` are respected.

Closes https://github.com/google/json_serializable.dart/issues/1577