### PR TITLE
chore(deps): support analyzer <15.0.0

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.14.1
+
+- Require `analyzer: '>=10.0.0 <15.0.0'`
+
 ## 6.14.0
 
 - Support `JsonKey.explicitJsonNullWhenNonNullField` for PATCH-style tri-state

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 6.14.0
+version: 6.14.1
 description: >-
   Automatically generate code for converting to and from JSON by annotating
   Dart classes.
@@ -15,7 +15,7 @@ topics:
 resolution: workspace
 
 dependencies:
-  analyzer: '>=10.0.0 <14.0.0'
+  analyzer: '>=10.0.0 <15.0.0'
   async: ^2.10.0
   build: ^4.0.4
   build_config: ^1.2.0


### PR DESCRIPTION
- Expand `analyzer` constraint to `<15.0.0` in `json_serializable`.
- Bump version to `6.14.1`.
