### PR TITLE
fix(json_serializable): improve error for unmatched ctor parameters

### DIFF
--- a/json_serializable/lib/src/decode_helper.dart
+++ b/json_serializable/lib/src/decode_helper.dart
@@ -308,7 +308,8 @@ mixin DecodeHelper implements HelperCore {
 ///
 /// To improve the error details, [unavailableReasons] is checked for the
 /// unavailable constructor parameter. If the value is not `null`, it is
-/// included in the [UnsupportedError] message.
+/// included in the [UnsupportedError] message; otherwise a default explanation
+/// is provided.
 ///
 /// [writableFields] are also populated, but only if they have not already
 /// been defined by a constructor parameter with the same name.
@@ -336,11 +337,10 @@ _ConstructorData _writeConstructorInvocation(
             'Cannot populate the required constructor '
             'argument: ${arg.name}.';
 
-        final additionalInfo = unavailableReasons[arg.name];
-
-        if (additionalInfo != null) {
-          msg = '$msg $additionalInfo';
-        }
+        final additionalInfo =
+            unavailableReasons[arg.name] ??
+            'It does not correspond to any field or getter on the class.';
+        msg = '$msg $additionalInfo';
 
         throw InvalidGenerationSourceError(msg, element: ctor);
       }

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -157,6 +157,7 @@ const _expectedAnnotatedTests = {
   'Reproduce869NullableGenericTypeWithDefault',
   'SameCtorAndJsonKeyDefaultValue',
   'SetSupport',
+  'StandaloneCtorParamClass',
   'SubclassedJsonKey',
   'SubType',
   'SubTypeWithAnnotatedFieldOverrideExtends',

--- a/json_serializable/test/src/_json_serializable_test_input.dart
+++ b/json_serializable/test/src/_json_serializable_test_input.dart
@@ -327,6 +327,17 @@ class PrivateFieldCtorClass {
 }
 
 @ShouldThrow(
+  'Cannot populate the required constructor argument: '
+  'standaloneParam. It does not correspond to any field or getter on the '
+  'class.',
+  element: 'new',
+)
+@JsonSerializable()
+class StandaloneCtorParamClass {
+  StandaloneCtorParamClass({required int standaloneParam});
+}
+
+@ShouldThrow(
   'Error with `@JsonKey` on the `field` field. '
   'Cannot set both `disallowNullValue` and `includeIfNull` to `true`. '
   'This leads to incompatible `toJson` and `fromJson` behavior.',

--- a/json_serializable/test/src/_json_serializable_test_input.dart
+++ b/json_serializable/test/src/_json_serializable_test_input.dart
@@ -334,6 +334,7 @@ class PrivateFieldCtorClass {
 )
 @JsonSerializable()
 class StandaloneCtorParamClass {
+  // ignore: avoid_unused_constructor_parameters
   StandaloneCtorParamClass({required int standaloneParam});
 }
 


### PR DESCRIPTION
- Append default explanation when an unavailable required constructor argument lacks a matching field or getter on the class.
- Add test case asserting the diagnostic message when constructor parameters have no corresponding properties.

Fixes #1583
